### PR TITLE
Add individual feature toggle settings (#22)

### DIFF
--- a/src/features/breather/index.js
+++ b/src/features/breather/index.js
@@ -3,10 +3,12 @@
  * Provides short rest alternatives for recovery
  */
 
+import { registerBreatherSettings } from './settings';
 import { registerBreatherUI } from './ui';
 
 export function registerBreatherFeature() {
     console.log('SoSly 5e House Rules | Registering Breather Rest System');
 
+    registerBreatherSettings();
     registerBreatherUI();
 }

--- a/src/features/breather/settings.js
+++ b/src/features/breather/settings.js
@@ -1,0 +1,16 @@
+/**
+ * Breather Rest System Settings
+ */
+
+export function registerBreatherSettings() {
+    game.settings.register('sosly-5e-house-rules', 'breather', {
+        name: game.i18n.localize('sosly.breather.label'),
+        hint: game.i18n.localize('sosly.breather.hint'),
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        restricted: true,
+        requiresReload: true
+    });
+}

--- a/src/features/breather/ui.js
+++ b/src/features/breather/ui.js
@@ -11,6 +11,10 @@ import { performBreather } from './rest-handler';
  * @param {HTMLElement} el - The sheet HTML element
  */
 function addBreatherButton(app, el) {
+    if (!game.settings.get('sosly-5e-house-rules', 'breather')) {
+        return;
+    }
+
     const buttons = el.querySelector('.sheet-header-buttons');
     if (!buttons) return;
 

--- a/src/features/concentration/index.js
+++ b/src/features/concentration/index.js
@@ -3,20 +3,31 @@
  * Handles concentration spell management during rests
  */
 
+import { registerConcentrationSettings } from './settings';
 import { handleConcentrationRest } from './rest-handler';
 
 export function registerConcentrationFeature() {
     console.log('SoSly 5e House Rules | Registering Concentration Management');
 
+    registerConcentrationSettings();
+
     Hooks.on('dnd5e.shortRest', async (actor, data) => {
-        await handleConcentrationRest(actor);
+        if (game.settings.get('sosly-5e-house-rules', 'concentration')) {
+            await handleConcentrationRest(actor);
+        }
     });
 
     Hooks.on('dnd5e.longRest', async (actor, data) => {
-        await handleConcentrationRest(actor);
+        if (game.settings.get('sosly-5e-house-rules', 'concentration')) {
+            await handleConcentrationRest(actor);
+        }
     });
 
+    // Hook breather events, but check both settings
     Hooks.on('sosly.breather', async actor => {
-        await handleConcentrationRest(actor);
+        if (game.settings.get('sosly-5e-house-rules', 'concentration')
+            && game.settings.get('sosly-5e-house-rules', 'breather')) {
+            await handleConcentrationRest(actor);
+        }
     });
 }

--- a/src/features/concentration/settings.js
+++ b/src/features/concentration/settings.js
@@ -1,0 +1,16 @@
+/**
+ * Concentration Management Settings
+ */
+
+export function registerConcentrationSettings() {
+    game.settings.register('sosly-5e-house-rules', 'concentration', {
+        name: game.i18n.localize('sosly.concentration.label'),
+        hint: game.i18n.localize('sosly.concentration.hint'),
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        restricted: true,
+        requiresReload: true
+    });
+}

--- a/src/features/encumbrance/index.js
+++ b/src/features/encumbrance/index.js
@@ -3,18 +3,23 @@
  * Provides enhanced encumbrance calculations for actors using libWrapper
  */
 
+import { registerEncumbranceSettings } from './settings';
 import { prepareEncumbrance } from './encumbrance.js';
 import { registerEncumbranceHooks } from './hooks.js';
 
 export function registerEncumbranceFeature() {
     console.log('SoSly 5e House Rules | Registering Encumbrance System (libWrapper)');
 
-    registerEncumbranceHooks();
+    registerEncumbranceSettings();
 
-    // Use libWrapper to wrap the D&D 5e system's prepareEncumbrance method
-    // This is more targeted than wrapping prepareDerivedData
-    libWrapper.register('sosly-5e-house-rules', 'dnd5e.dataModels.actor.AttributesFields.prepareEncumbrance', function(wrapped, rollData, options = {}) {
-        // Apply our custom encumbrance calculations instead of the system's
-        prepareEncumbrance.call(this, rollData, options);
-    }, 'OVERRIDE');
+    if (game.settings.get('sosly-5e-house-rules', 'encumbrance')) {
+        registerEncumbranceHooks();
+
+        // Use libWrapper to wrap the D&D 5e system's prepareEncumbrance method
+        // This is more targeted than wrapping prepareDerivedData
+        libWrapper.register('sosly-5e-house-rules', 'dnd5e.dataModels.actor.AttributesFields.prepareEncumbrance', function(wrapped, rollData, options = {}) {
+            // Apply our custom encumbrance calculations instead of the system's
+            prepareEncumbrance.call(this, rollData, options);
+        }, 'OVERRIDE');
+    }
 }

--- a/src/features/encumbrance/settings.js
+++ b/src/features/encumbrance/settings.js
@@ -1,0 +1,16 @@
+/**
+ * Custom Encumbrance Settings
+ */
+
+export function registerEncumbranceSettings() {
+    game.settings.register('sosly-5e-house-rules', 'encumbrance', {
+        name: game.i18n.localize('sosly.encumbrance.label'),
+        hint: game.i18n.localize('sosly.encumbrance.hint'),
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        restricted: true,
+        requiresReload: true
+    });
+}

--- a/src/features/imperiled/index.js
+++ b/src/features/imperiled/index.js
@@ -3,6 +3,7 @@
  * Manages the Imperiled condition and related mechanics
  */
 
+import { registerImperiledSettings } from './settings';
 import { registerImperiledConditions } from './conditions';
 import { handleImperiled } from './combat';
 import { handleImperiledUpdate } from './actor-updates';
@@ -10,13 +11,18 @@ import { handleImperiledUpdate } from './actor-updates';
 export function registerImperiledFeature() {
     console.log('SoSly 5e House Rules | Registering Imperiled Condition');
 
+    registerImperiledSettings();
     registerImperiledConditions();
 
     Hooks.on('combatTurnChange', async (combat, previous, next) => {
-        await handleImperiled(combat, previous, next);
+        if (game.settings.get('sosly-5e-house-rules', 'imperiled')) {
+            await handleImperiled(combat, previous, next);
+        }
     });
 
     Hooks.on('preUpdateActor', async (actor, changed, options, userId) => {
-        await handleImperiledUpdate(actor, changed, options, userId);
+        if (game.settings.get('sosly-5e-house-rules', 'imperiled')) {
+            await handleImperiledUpdate(actor, changed, options, userId);
+        }
     });
 }

--- a/src/features/imperiled/settings.js
+++ b/src/features/imperiled/settings.js
@@ -1,0 +1,16 @@
+/**
+ * Imperiled Condition System Settings
+ */
+
+export function registerImperiledSettings() {
+    game.settings.register('sosly-5e-house-rules', 'imperiled', {
+        name: game.i18n.localize('sosly.imperiled.label'),
+        hint: game.i18n.localize('sosly.imperiled.hint'),
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        restricted: true,
+        requiresReload: true
+    });
+}

--- a/src/features/rest-enhancements/index.js
+++ b/src/features/rest-enhancements/index.js
@@ -3,17 +3,24 @@
  * Provides enhanced rest mechanics and recovery
  */
 
+import { registerRestEnhancementsSettings } from './settings';
 import { handleShortRest } from './short-rest';
 import { handleCombatRecovery } from './combat-recovery';
 
 export function registerRestEnhancementsFeature() {
     console.log('SoSly 5e House Rules | Registering Rest Enhancements');
 
+    registerRestEnhancementsSettings();
+
     Hooks.on('dnd5e.shortRest', async (actor, data) => {
-        await handleShortRest(actor, data);
+        if (game.settings.get('sosly-5e-house-rules', 'rest-enhancements')) {
+            await handleShortRest(actor, data);
+        }
     });
 
     Hooks.on('dnd5e.combatRecovery', async (combatant, recoveries) => {
-        await handleCombatRecovery(combatant, recoveries);
+        if (game.settings.get('sosly-5e-house-rules', 'rest-enhancements')) {
+            await handleCombatRecovery(combatant, recoveries);
+        }
     });
 }

--- a/src/features/rest-enhancements/settings.js
+++ b/src/features/rest-enhancements/settings.js
@@ -1,0 +1,16 @@
+/**
+ * Rest Enhancements Settings
+ */
+
+export function registerRestEnhancementsSettings() {
+    game.settings.register('sosly-5e-house-rules', 'rest-enhancements', {
+        name: game.i18n.localize('sosly.rest-enhancements.label'),
+        hint: game.i18n.localize('sosly.rest-enhancements.hint'),
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        restricted: true,
+        requiresReload: true
+    });
+}

--- a/src/lang/en.yaml
+++ b/src/lang/en.yaml
@@ -2,17 +2,29 @@ sosly:
   conditions:
     Imperiled: Imperiled
   breather:
-    label: Breather
-    hint: Take a breather? On a breather, you may spend remaining Hit Dice.
+    label: Breathers
+    hint: Enables the breather rest system that allows spending Hit Dice for recovery without a full short rest.
+    title: Breather
+    confirmation: Take a breather? On a breather, you may spend remaining Hit Dice.
     select: Select Dice to Roll
     nohd: No Hit Dice remaining.
   concentration:
+    label: Concentration Management
+    hint: Automates concentration management during rests.
     title: Concentration
     confirmation: Your character is concentrating on {spell}. Do you want to end concentration?
   imperiled:
+    label: Imperiled Condition
+    hint: Enables the Imperiled condition that triggers when characters reach 0 hit points.
     title: Imperiled
     confirmation: Your character is imperiled!  You can gain a level of Exhaustion to remain conscious. You currently have {exhaustion} levels of exhaustion.  Do you want to do this?
   madness:
     label: Madness
     hint: Enables a madness counter for Player Characters.
+  rest-enhancements:
+    label: Gritty Rest Mechanics
+    hint: Enables gritty rest mechanics that change how short and long rests function.
+  encumbrance:
+    label: Equipped Encumbrance
+    hint: Equipped items count as half weight for encumbrance calculations.
   networth: Net Worth


### PR DESCRIPTION
## Summary
- Adds granular settings to enable/disable individual house rule features
- Each feature can be independently controlled by GMs via module settings
- Maintains backward compatibility with all features enabled by default

## Features with New Settings
- **Breathers** - Toggle the breather rest system
- **Imperiled Condition** - Toggle imperiled condition mechanics  
- **Concentration Management** - Toggle automatic concentration handling during rests
- **Gritty Rest Mechanics** - Toggle enhanced rest mechanics
- **Equipped Encumbrance** - Toggle custom encumbrance calculations

## Implementation Details
- Settings are world-scoped, GM-restricted, and require reload
- Features check settings before registering hooks or applying modifications
- Concentration feature properly handles dependency on breather feature
- libWrapper integration only registers when encumbrance feature is enabled
- Added comprehensive localization with descriptive labels and hints

## Test Plan
- [x] All features default to enabled (maintains current behavior)
- [x] Each feature can be individually disabled via settings
- [x] Disabled features don't interfere with core D&D 5e functionality
- [x] Concentration properly checks both its own setting and breather setting
- [x] Module builds without errors
- [x] No console errors when features are disabled

🤖 Generated with [Claude Code](https://claude.ai/code)