### PR TITLE
feat: update Breather to ApplicationV2 (#21)

### DIFF
--- a/templates/features/breather/breather.hbs
+++ b/templates/features/breather/breather.hbs
@@ -1,29 +1,18 @@
-<form id="breather-hd" class="dialog-content" onsubmit="event.preventDefault();">
-    <p>{{ localize 'sosly.breather.hint' }}</p>
+<p>{{ localize 'sosly.breather.hint' }}</p>
 
-    {{#if availableHD}}
-    <div class="form-group">
-        <label>{{ localize 'sosly.breather.select' }}</label>
-        <div class="form-fields">
-            <select name="hd">
-                {{ selectOptions hdOptions selected=denomination }}
-            </select>
-            <button id="roll-hd" {{#unless canRoll}}disabled{{/unless}}>
-                <i class="fas fa-dice-d20"></i> {{ localize 'DND5E.Roll' }}
-            </button>
-        </div>
-        {{#unless canRoll}}
-            <p class="notes">{{ localize 'sosly.breather.nohd'}}</p>
-        {{/unless}}
+{{#if availableHD}}
+<div class="form-group">
+    <label>{{ localize 'sosly.breather.select' }}</label>
+    <div class="form-fields">
+        <select name="hd">
+            {{ selectOptions hdOptions selected=denomination }}
+        </select>
+        <button type="button" id="roll-hd" {{#unless canRoll}}disabled{{/unless}}>
+            <i class="fas fa-dice-d20"></i> {{ localize 'DND5E.Roll' }}
+        </button>
     </div>
-    {{/if}}
-
-    <div class="dialog-buttons">
-        {{#each buttons as |button id|}}
-            <button class="dialog-button" data-button="{{id}}">
-                {{{button.icon}}}
-                {{{button.label}}}
-            </button>
-        {{/each}}
-    </div>
-</form>
+    {{#unless canRoll}}
+        <p class="notes">{{ localize 'sosly.breather.nohd'}}</p>
+    {{/unless}}
+</div>
+{{/if}}


### PR DESCRIPTION
## Summary
- Migrated Breather dialog from legacy Dialog class to modern DialogV2
- Maintained identical functionality and user experience
- Fixed button localization to use current DND5e system keys

## Changes Made
- **Architecture**: Converted from class extension to static factory pattern using `DialogV2`
- **Rendering**: Updated to use `DialogV2.render({ force: true })` pattern like other modules
- **Event Handling**: Implemented custom render hook for hit dice rolling functionality
- **Template**: Simplified template structure removing dialog-specific wrapper
- **Localization**: Updated button label to use `DND5E.REST.Label`

## Testing
- ✅ Dialog appears correctly
- ✅ Hit dice selection and rolling works
- ✅ Form submission collects data properly
- ✅ Cancel functionality works
- ✅ Styling and UX preserved
- ✅ Works with both NPC and PC actors

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)