### PR TITLE
refactor: migrate dialogs to DialogV2 and eliminate code duplication

### DIFF
--- a/src/features/concentration/playwright.js
+++ b/src/features/concentration/playwright.js
@@ -189,13 +189,13 @@ async function castConcentrationSpell(page, actorId) {
 }
 
 async function endConcentration(page) {
-    await page.waitForSelector('div.app.dialog:has(.window-title:text("Concentration"))', {timeout: 5000});
+    await page.waitForSelector('dialog.rest-concentration', {timeout: 5000});
 
     // Verify concentration dialog content
-    const concentrationDialog = page.locator('div.app.dialog:has(.window-title:text("Concentration"))');
+    const concentrationDialog = page.locator('dialog.rest-concentration');
     await expect(concentrationDialog).toContainText('concentrating on Playwright Concentration Spell');
     await expect(concentrationDialog).toContainText('end concentration');
 
     // Confirm to end concentration
-    await page.click('div.app.dialog:has(.window-title:text("Concentration")) button[data-button="yes"]');
+    await page.click('dialog.rest-concentration button[data-action="yes"]');
 }

--- a/src/features/concentration/quench.js
+++ b/src/features/concentration/quench.js
@@ -50,16 +50,16 @@ export function registerConcentrationTests() {
                             }
                         };
 
-                        // Mock Dialog.confirm to return true
-                        const originalConfirm = Dialog.confirm;
-                        Dialog.confirm = async () => true;
+                        // Mock DialogV2.confirm to return true
+                        const originalConfirm = foundry.applications.api.DialogV2.confirm;
+                        foundry.applications.api.DialogV2.confirm = async () => true;
 
                         await handleConcentrationRest(mockActor);
 
                         assert.isTrue(effectDeleted, 'Effect should be deleted when confirmed');
 
                         // Restore original Dialog.confirm
-                        Dialog.confirm = originalConfirm;
+                        foundry.applications.api.DialogV2.confirm = originalConfirm;
                     });
 
                     it('should not delete effect when user cancels confirmation', async function() {
@@ -79,16 +79,16 @@ export function registerConcentrationTests() {
                             }
                         };
 
-                        // Mock Dialog.confirm to return false
-                        const originalConfirm = Dialog.confirm;
-                        Dialog.confirm = async () => false;
+                        // Mock DialogV2.confirm to return false
+                        const originalConfirm = foundry.applications.api.DialogV2.confirm;
+                        foundry.applications.api.DialogV2.confirm = async () => false;
 
                         await handleConcentrationRest(mockActor);
 
                         assert.isFalse(effectDeleted, 'Effect should not be deleted when cancelled');
 
                         // Restore original Dialog.confirm
-                        Dialog.confirm = originalConfirm;
+                        foundry.applications.api.DialogV2.confirm = originalConfirm;
                     });
 
                     it('should extract spell name from concentration effect label', async function() {
@@ -108,9 +108,9 @@ export function registerConcentrationTests() {
                             }
                         };
 
-                        // Mock Dialog.confirm to capture content
-                        const originalConfirm = Dialog.confirm;
-                        Dialog.confirm = async options => {
+                        // Mock DialogV2.confirm to capture content
+                        const originalConfirm = foundry.applications.api.DialogV2.confirm;
+                        foundry.applications.api.DialogV2.confirm = async options => {
                             dialogContent = options.content;
                             return true;
                         };
@@ -131,7 +131,7 @@ export function registerConcentrationTests() {
                         assert.include(dialogContent, 'Shield of Faith', 'Dialog should contain extracted spell name');
 
                         // Restore original functions
-                        Dialog.confirm = originalConfirm;
+                        foundry.applications.api.DialogV2.confirm = originalConfirm;
                         if (game.i18n && originalFormat) {
                             game.i18n.format = originalFormat;
                         }

--- a/src/features/concentration/rest-handler.js
+++ b/src/features/concentration/rest-handler.js
@@ -17,9 +17,15 @@ export async function handleConcentrationRest(actor) {
 
     for (const effect of concentrating) {
         const confirmContent = game.i18n?.format('sosly.concentration.confirmation', {spell: effect.label.replace(/Concentrating:\s+/, '')});
-        const confirmation = await Dialog.confirm({
-            title: game.i18n?.localize('sosly.concentration.title'),
-            content: confirmContent
+        const confirmation = await foundry.applications.api.DialogV2.confirm({
+            window: {
+                title: game.i18n?.localize('sosly.concentration.title'),
+            },
+            classes: ['rest-concentration'],
+            position: { width: 400 },
+            content: `<p>${confirmContent}</p>`,
+            yes: {},
+            no: {}
         });
 
         if (!confirmation) {

--- a/src/features/imperiled/ui.js
+++ b/src/features/imperiled/ui.js
@@ -1,0 +1,56 @@
+/**
+ * UI functions for Imperiled feature
+ */
+
+import {id as module_id} from '../../../module.json';
+
+/**
+ * Show imperiled confirmation dialog
+ * @param {number} exhaustion - Current exhaustion level
+ * @returns {Promise<boolean>} True if user chooses to remain conscious
+ */
+export async function showImperiledDialog(exhaustion) {
+    const confirmContent = game.i18n?.format('sosly.imperiled.confirmation', {exhaustion});
+    return foundry.applications.api.DialogV2.confirm({
+        window: {
+            title: game.i18n?.localize('sosly.imperiled.title'),
+        },
+        classes: ['imperiled'],
+        position: { width: 400 },
+        content: `<p>${confirmContent}</p>`,
+        yes: {},
+        no: {}
+    });
+}
+
+/**
+ * Apply unconscious effect to actor and remove imperiled
+ * @param {Actor} actor - The actor to apply unconscious to
+ * @param {ActiveEffect} imperiledEffect - The imperiled effect to remove
+ * @param {string} reason - Reason for falling unconscious
+ */
+export async function applyUnconscious(actor, imperiledEffect, reason = 'falls unconscious and is no longer imperiled') {
+    if (imperiledEffect) await imperiledEffect.delete();
+
+    const effect = await ActiveEffect.implementation.fromStatusEffect('unconscious');
+    await ActiveEffect.implementation.create(effect, { parent: actor, keepId: true});
+
+    await createImperiledChatMessage(actor, `${actor.name} ${reason}.`);
+}
+
+/**
+ * Create imperiled-related chat message
+ * @param {Actor} actor - The actor for the message
+ * @param {string} text - The message text
+ */
+export async function createImperiledChatMessage(actor, text) {
+    const content = await renderTemplate(`modules/${module_id}/templates/features/imperiled/Imperiled.hbs`, {
+        text
+    });
+
+    await ChatMessage.create({
+        user: game.user.id,
+        speaker: {actor, alias: actor.name},
+        content
+    });
+}


### PR DESCRIPTION
## Summary
This PR modernizes our dialog implementations by migrating from the legacy `Dialog.confirm()` to the modern `foundry.applications.api.DialogV2.confirm()` pattern, following D&D5e system conventions. Additionally, it significantly reduces code duplication in the imperiled feature.

## Changes

### Dialog Migration
- **Imperiled feature**: Migrated confirmation dialogs to DialogV2
- **Concentration feature**: Migrated rest confirmation dialog to DialogV2
- Added CSS classes to dialogs for potential custom styling:
  - `.imperiled` for imperiled dialogs
  - `.rest-concentration` for concentration rest dialogs

### Code Refactoring
- Created `src/features/imperiled/ui.js` with shared UI functions:
  - `showImperiledDialog()` - Displays the imperiled confirmation dialog
  - `applyUnconscious()` - Applies unconscious effect and removes imperiled
  - `createImperiledChatMessage()` - Creates chat messages for imperiled events
- Eliminated duplicate code between `combat.js` and `actor-updates.js`
- Updated all tests to mock DialogV2 instead of Dialog

## Benefits
- Consistent with modern FoundryVTT ApplicationV2 patterns
- Follows D&D5e system conventions (see `deleteDialog` implementation)
- Better dialog styling and customization options
- Significant code reduction (~80 lines removed, 90 added including new functionality)
- Improved maintainability with shared functions

## Testing
- All unit tests updated and passing
- Playwright tests updated with new selectors
- Build completes without errors
- Manual testing recommended for dialog behavior

## Related Issues
- Addresses part of #30 (DialogV2 migration)
- Also created #40 for future module ID refactoring

🤖 Generated with [Claude Code](https://claude.ai/code)