### PR TITLE
chore: replace hardcoded module ID strings with module_id import

### DIFF
--- a/src/features/breather/breather.js
+++ b/src/features/breather/breather.js
@@ -1,4 +1,5 @@
 import {findBestHitDie, formatHitDieOptions} from './calculations';
+import {id as module_id} from '../../../module.json';
 
 const BaseRestDialog = dnd5e.applications.actor.BaseRestDialog;
 
@@ -11,7 +12,7 @@ class BreatherDialog extends BaseRestDialog {
         return {
             ...super.PARTS,
             content: {
-                template: 'modules/sosly-5e-house-rules/templates/features/breather/breather.hbs'
+                template: `modules/${module_id}/templates/features/breather/breather.hbs`
             }
         };
     }

--- a/src/features/breather/index.js
+++ b/src/features/breather/index.js
@@ -1,3 +1,5 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Breather Rest System Feature
  * Provides short rest alternatives for recovery
@@ -12,7 +14,7 @@ export function registerBreatherFeature() {
 
     registerBreatherSettings();
 
-    if (game.settings.get('sosly-5e-house-rules', 'breather')) {
+    if (game.settings.get(module_id, 'breather')) {
         BreatherUI.register();
     }
 

--- a/src/features/breather/settings.js
+++ b/src/features/breather/settings.js
@@ -1,9 +1,11 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Breather Rest System Settings
  */
 
 export function registerBreatherSettings() {
-    game.settings.register('sosly-5e-house-rules', 'breather', {
+    game.settings.register(module_id, 'breather', {
         name: game.i18n.localize('sosly.breather.label'),
         hint: game.i18n.localize('sosly.breather.hint'),
         scope: 'world',

--- a/src/features/concentration/index.js
+++ b/src/features/concentration/index.js
@@ -1,3 +1,5 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Concentration Management Feature
  * Handles concentration spell management during rests
@@ -19,7 +21,7 @@ export function registerConcentrationFeature() {
     });
 
     // Also handle breather if that feature is enabled
-    if (game.settings.get('sosly-5e-house-rules', 'breather')) {
+    if (game.settings.get(module_id, 'breather')) {
         Hooks.on('sosly.breather', async actor => {
             await handleConcentrationRest(actor);
         });

--- a/src/features/encumbrance/index.js
+++ b/src/features/encumbrance/index.js
@@ -1,3 +1,5 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Encumbrance System Feature
  * Provides enhanced encumbrance calculations for actors using libWrapper
@@ -18,12 +20,12 @@ export function registerEncumbranceFeature() {
         registerEncumbranceTests();
     }
 
-    if (game.settings.get('sosly-5e-house-rules', 'encumbrance')) {
+    if (game.settings.get(module_id, 'encumbrance')) {
         registerEncumbranceHooks();
 
         // Use libWrapper to wrap the D&D 5e system's prepareEncumbrance method
         // This is more targeted than wrapping prepareDerivedData
-        libWrapper.register('sosly-5e-house-rules', 'dnd5e.dataModels.actor.AttributesFields.prepareEncumbrance', function(wrapped, rollData, options = {}) {
+        libWrapper.register(module_id, 'dnd5e.dataModels.actor.AttributesFields.prepareEncumbrance', function(wrapped, rollData, options = {}) {
             // Apply our custom encumbrance calculations instead of the system's
             prepareEncumbrance.call(this, rollData, options);
         }, 'OVERRIDE');

--- a/src/features/encumbrance/settings.js
+++ b/src/features/encumbrance/settings.js
@@ -1,9 +1,11 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Custom Encumbrance Settings
  */
 
 export function registerEncumbranceSettings() {
-    game.settings.register('sosly-5e-house-rules', 'encumbrance', {
+    game.settings.register(module_id, 'encumbrance', {
         name: game.i18n.localize('sosly.encumbrance.label'),
         hint: game.i18n.localize('sosly.encumbrance.hint'),
         scope: 'world',

--- a/src/features/imperiled/index.js
+++ b/src/features/imperiled/index.js
@@ -1,3 +1,5 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Imperiled Condition Feature
  * Manages the Imperiled condition and related mechanics
@@ -21,13 +23,13 @@ export function registerImperiledFeature() {
     }
 
     Hooks.on('combatTurnChange', async (combat, previous, next) => {
-        if (game.settings.get('sosly-5e-house-rules', 'imperiled')) {
+        if (game.settings.get(module_id, 'imperiled')) {
             await handleImperiled(combat, previous, next);
         }
     });
 
     Hooks.on('preUpdateActor', async (actor, changed, options, userId) => {
-        if (game.settings.get('sosly-5e-house-rules', 'imperiled')) {
+        if (game.settings.get(module_id, 'imperiled')) {
             await handleImperiledUpdate(actor, changed, options, userId);
         }
     });

--- a/src/features/imperiled/settings.js
+++ b/src/features/imperiled/settings.js
@@ -1,9 +1,11 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Imperiled Condition System Settings
  */
 
 export function registerImperiledSettings() {
-    game.settings.register('sosly-5e-house-rules', 'imperiled', {
+    game.settings.register(module_id, 'imperiled', {
         name: game.i18n.localize('sosly.imperiled.label'),
         hint: game.i18n.localize('sosly.imperiled.hint'),
         scope: 'world',

--- a/src/features/madness/settings.js
+++ b/src/features/madness/settings.js
@@ -1,9 +1,11 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Madness Tracking Settings
  */
 
 export function registerMadnessSettings() {
-    game.settings.register('sosly-5e-house-rules', 'madness', {
+    game.settings.register(module_id, 'madness', {
         name: game.i18n.localize('sosly.madness.label'),
         hint: game.i18n.localize('sosly.madness.hint'),
         scope: 'world',

--- a/src/features/madness/ui.js
+++ b/src/features/madness/ui.js
@@ -1,3 +1,5 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Madness Tracking UI Integration
  * Adds madness level tracking to character sheets
@@ -9,7 +11,7 @@
  * @param {HTMLElement} el - The sheet HTML element
  */
 function addMadnessTracking(app, el) {
-    if (!game.settings.get('sosly-5e-house-rules', 'madness')) {
+    if (!game.settings.get(module_id, 'madness')) {
         return;
     }
 

--- a/src/features/multiple-concentration/handler.js
+++ b/src/features/multiple-concentration/handler.js
@@ -1,3 +1,5 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Concentration Handler for Multiple Concentration
  * Handles HD expenditure when maintaining multiple concentrations
@@ -65,7 +67,7 @@ export function registerConcentrationHandler() {
         // Post chat message using template
         if (hdExpended || error) {
             const content = await renderTemplate(
-                'modules/sosly-5e-house-rules/templates/features/multiple-concentration/chat-message.hbs',
+                `modules/${module_id}/templates/features/multiple-concentration/chat-message.hbs`,
                 {
                     actor: actor.name,
                     die: hdExpended,

--- a/src/features/multiple-concentration/index.js
+++ b/src/features/multiple-concentration/index.js
@@ -1,3 +1,5 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Multiple Concentration Feature
  * Allows characters to concentrate on two spells simultaneously by expending a Hit Die
@@ -12,7 +14,7 @@ export function registerMultipleConcentrationFeature() {
 
     registerMultipleConcentrationSettings();
 
-    const isEnabled = game.settings.get('sosly-5e-house-rules', 'multipleConcentration');
+    const isEnabled = game.settings.get(module_id, 'multipleConcentration');
 
     // Always run setup to handle enable/disable state
     Hooks.once('setup', async () => {

--- a/src/features/multiple-concentration/settings.js
+++ b/src/features/multiple-concentration/settings.js
@@ -1,9 +1,11 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Multiple Concentration Settings
  */
 
 export function registerMultipleConcentrationSettings() {
-    game.settings.register('sosly-5e-house-rules', 'multipleConcentration', {
+    game.settings.register(module_id, 'multipleConcentration', {
         name: game.i18n.localize('sosly.concentration.multiple.label'),
         hint: game.i18n.localize('sosly.concentration.multiple.hint'),
         scope: 'world',

--- a/src/features/rest-enhancements/index.js
+++ b/src/features/rest-enhancements/index.js
@@ -1,3 +1,5 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Rest Enhancements Feature
  * Provides enhanced rest mechanics and recovery
@@ -19,13 +21,13 @@ export function registerRestEnhancementsFeature() {
     }
 
     Hooks.on('dnd5e.shortRest', async (actor, data) => {
-        if (game.settings.get('sosly-5e-house-rules', 'rest-enhancements')) {
+        if (game.settings.get(module_id, 'rest-enhancements')) {
             await handleShortRest(actor, data);
         }
     });
 
     Hooks.on('dnd5e.combatRecovery', async (combatant, recoveries) => {
-        if (game.settings.get('sosly-5e-house-rules', 'rest-enhancements')) {
+        if (game.settings.get(module_id, 'rest-enhancements')) {
             await handleCombatRecovery(combatant, recoveries);
         }
     });

--- a/src/features/rest-enhancements/settings.js
+++ b/src/features/rest-enhancements/settings.js
@@ -1,9 +1,11 @@
+import {id as module_id} from '../../../module.json';
+
 /**
  * Rest Enhancements Settings
  */
 
 export function registerRestEnhancementsSettings() {
-    game.settings.register('sosly-5e-house-rules', 'rest-enhancements', {
+    game.settings.register(module_id, 'rest-enhancements', {
         name: game.i18n.localize('sosly.rest-enhancements.label'),
         hint: game.i18n.localize('sosly.rest-enhancements.hint'),
         scope: 'world',


### PR DESCRIPTION
## Summary
- Replaces all hardcoded `'sosly-5e-house-rules'` strings with imported `module_id` variable
- Single source of truth for module ID from `module.json`
- Makes the module easier to fork or rename

## Changes
- Added `import {id as module_id} from '../../../module.json';` to 15 JavaScript files
- Updated all settings registration and retrieval to use `module_id`
- Updated template paths to use template literals with `module_id`
- Updated libWrapper registration to use `module_id`

## Not Changed
- Test helper functions - Tests need explicit values for reliability
- Compendium references - These are data paths, not configuration
- SCSS background image path - CSS/SCSS cannot import JavaScript variables

## Test Plan
- [x] All existing integration tests pass
- [x] Build completes without errors
- [x] ESLint passes

Closes #40

🤖 Generated with [Claude Code](https://claude.ai/code)