### PR TITLE
fix: correct psionic power point costs display on character sheets

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "comma-style": "warn",
     "computed-property-spacing": "warn",
     "constructor-super": "error",
+    "curly": ["error", "all"],
     "default-param-last": "warn",
     "dot-location": ["warn", "property"],
     "eol-last": ["error", "always"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,139 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- Fix psionic power point costs not displaying on character sheet spell subtitles by using correct v4 sheet hooks (renderActorSheet5eCharacter2/renderActorSheet5eNPC2)
+- Correct power point extraction to check character's spell-points item instead of compendium reference
+
+### Changed
+- Enforce curly braces for all control structures with new ESLint rule
+- Migrate psionic subtitle UI from jQuery to native DOM APIs
+
+## [1.18.5](https://github.com/nivthefox/foundryvtt-sosly-5e-house-rules/releases/tag/v1.18.5) - 2025-10-02
+
+### Fixed
+- Correct psionic discipline folder organization
+
+## [1.18.4](https://github.com/nivthefox/foundryvtt-sosly-5e-house-rules/releases/tag/v1.18.4) - 2025-10-02
+
+### Added
+- Organize psionic disciplines into folders
+
+### Changed
+- Rename fire-related psionic files to follow underscore naming convention
+
+## [1.18.3](https://github.com/nivthefox/foundryvtt-sosly-5e-house-rules/releases/tag/v1.18.3) - 2025-10-02
+
+### Fixed
+- Replace invalid psionic power icons with valid Foundry assets across all 141 psionic documents
+
+## [1.18.2](https://github.com/nivthefox/foundryvtt-sosly-5e-house-rules/releases/tag/v1.18.2) - 2025-10-02
+
+### Fixed
+- Correct Avatar discipline subtype from 'avt' to 'ava' for all 10 Avatar disciplines
+
+## [1.18.1](https://github.com/nivthefox/foundryvtt-sosly-5e-house-rules/releases/tag/v1.18.1) - 2025-10-02
+
+### Fixed
+- Add missing psionic powers from OCR (Mantle of Joy: Comforting Aura, Aura of Jubilation, Beacon of Recovery; Alacrity: Death from Above)
+- Fix Hail of Crystals description to include missing difficult terrain effect
+
+## [1.18.0](https://github.com/nivthefox/foundryvtt-sosly-5e-house-rules/releases/tag/v1.18.0) - 2025-10-02
+
+### Added
+- Add comprehensive psionic disciplines and spells across multiple specializations (Avatar, Awakened, Immortal, Nomad, Soul Knife, Wu Jen)
+- Add document ID generation tool for content management
+
+## [1.17.0](https://github.com/nivthefox/foundryvtt-sosly-5e-house-rules/releases/tag/v1.17.0) - 2025-09-27
+
+### Added
+- Add Necromancer wizard subclass from 2024 PHB with features: Necromancy Savant, Necromancy Spellbook, Undead Thralls, Harvest Undead, Grave Power, Death's Master
+- Add Enchanter wizard subclass from 2024 PHB with features: Enchantment Savant, Hypnotic Presence, Enchanting Conversationalist, Instinctive Charm, Alter Memories, Split Enchantment
+
+## [1.16.4](https://github.com/nivthefox/foundryvtt-sosly-5e-house-rules/releases/tag/v1.16.4) - 2025-09-26
+
+### Fixed
+- Improve container drag-drop for Location actors with better drop target detection using elementFromPoint fallback
+- Add support for drops from external sources (compendiums, other actors) into container sheets
+
+## [1.16.3](https://github.com/nivthefox/foundryvtt-sosly-5e-house-rules/releases/tag/v1.16.3) - 2025-09-26
+
+### Fixed
+- Fix delete confirmation dialog to properly await user response before deletion in Location sheets
+- Fix duplicate items appearing when dragging consumables from external sources to Location sheets
+
+## [1.16.2](https://github.com/nivthefox/foundryvtt-sosly-5e-house-rules/releases/tag/v1.16.2) - 2025-09-26
+
+### Added
+- Enable container functionality for Location sheets
+
+### Fixed
+- Fix item duplication when dragging into containers on Location sheets
+- Properly hide items inside containers from main inventory display
+- Add hook to intercept container drops for Location actors
+- Handle recursive container prevention
+
+## [1.16.1](https://github.com/nivthefox/foundryvtt-sosly-5e-house-rules/releases/tag/v1.16.1) - 2025-09-26
+
+### Fixed
+- Fix Location sheet theme support so custom light backgrounds properly allow system dark mode styles to take precedence
+
+## [1.16.0](https://github.com/nivthefox/foundryvtt-sosly-5e-house-rules/releases/tag/1.16.0) - 2025-09-26
+
+### Added
+- Implement Severed Lands Blood Magic automation with madness saves, blood surge (natural 20 refunds spell slots), and hungry magic (natural 1 consumes slots/deals damage)
+- Add chat integration for Blood Magic with styled chat cards for GM madness effect selection
+- Add spell level tracking for Blood Magic madness effects with combat turn save re-attempts
+- Add comprehensive badge collection to README
+- Add location actor subtype with basic functionality including currency tracking, inventory management, location features, rich text descriptions, and tabbed interface
+- Complete D&D 5e visual integration for location sheet with vertical tabs and parchment background
+- Complete D&D 5e integration with edit/play modes for location sheet
+- Implement comprehensive inventory and currency system for location sheet with categorized sections and interactive coin interface
+- Implement proper D&D 5e context menu system for location sheet items using ContextMenu5e
+- Implement comprehensive expand/collapse functionality for location sheet items with dynamic icon switching
+- Implement proper container support with capacity display and contents management
+- Implement item dragging and triple-dot context menu functionality for location sheets
+- Implement Create Item functionality for Location sheets with context-aware item type filtering
+- Extract search/filter/sort to reusable ItemListControls component
+- Add group/ungroup toggle functionality to Location sheet
+- Add portrait popup to Location sheet (clickable in Play mode)
+- Add net worth display to Location sheets
+- Limit Imperiled condition to NPCs with linked tokens to prevent notification spam
+
+### Changed
+- Reorganize stylesheet architecture to match JavaScript structure, splitting monolithic SCSS into modular components
+- Implement centralized logging and clean up build configuration, replacing console.log statements with branded logger utility
+- Migrate inline HTML to Handlebars templates for Blood Magic
+- Standardize module ID usage across all JavaScript files using imported module_id constant
+- Apply D&D 5e styling to location sheet
+- Extract LocationSheet into manager architecture (80% reduction in main sheet complexity with separate managers for items, data preparation, and UI manipulation)
+- Apply Beautiful Coding standards to location feature
+- Migrate Location currency to dynamic MappingField system to support dynamic currencies from modules and campaign settings
+- Remove Features and Details tabs from Location sheet to focus on inventory management
+- Migrate inline HTML to Handlebars templates across location feature
+- Move item-list-controls from shared/ to components/ directory
+- Update .gitignore to properly exclude IDE configuration files
+
+### Fixed
+- Correct spell slot consumption detection for Blood Magic to check nested updates object structure
+- Resolve Blood Magic chat message persistence by updating chat message content when effects applied
+- Fix natural 1 detection bug for advantage/disadvantage rolls (checks active die instead of first die)
+- Correct README.md content to match SoSly House Rules module
+- Correct localization keys from SOSLY to sosly (lowercase) and remove redundant size field
+- Implement proper D&D 5e tab functionality for location sheet
+- Resolve consumable drag/drop errors with comprehensive error handling in item context preparation
+- Fix consumable subtitle generation with proper type validation and fallbacks
+- Correct item uses display to show full charges for new items (1/1 vs 0/1)
+- Resolve item drop issues and improve sheet overflow handling with proper scrollable tabs
+- Improve Location sheet scrolling and layout structure
+- Use proper item subtitle formatting in Location sheets (fixes raw i18n keys appearing)
+- Remove standard-form class and add header padding to Location sheets
+- Change Location sheet portrait from circular to square
+- Resolve Location Type field validation with phantom comma
+- Change container click behavior to open item sheet instead of using container

--- a/src/features/breather/breather.js
+++ b/src/features/breather/breather.js
@@ -109,7 +109,7 @@ export class Breather {
     async _handleFeatureRecovery(actor, config) {
         // Get recoverable features
         const recoverableFeatures = getRecoverableFeatures(actor);
-        if (!recoverableFeatures.length) return;
+        if (!recoverableFeatures.length) {return;}
 
         // Check which features were selected in the form
         const selectedFeatures = [];
@@ -121,7 +121,7 @@ export class Breather {
             }
         }
 
-        if (!selectedFeatures.length) return;
+        if (!selectedFeatures.length) {return;}
 
         // Validate hit dice availability
         const availableHD = actor.system.attributes.hd.value;
@@ -156,7 +156,7 @@ export class Breather {
     async _spendHitDie(actor) {
         const hd = actor.system.attributes.hd;
 
-        if (!hd.smallestAvailable || hd.value <= 0) return;
+        if (!hd.smallestAvailable || hd.value <= 0) {return;}
 
         // Find a class that has the smallest HD size and unspent HD
         const targetClass = Array.from(hd.classes)
@@ -178,7 +178,7 @@ export class Breather {
      */
     inject(app, el) {
         const buttons = el.querySelector('.sheet-header-buttons');
-        if (!buttons) return;
+        if (!buttons) {return;}
 
         const button = document.createElement('button');
         button.classList.add('breather-button', 'gold-button');

--- a/src/features/breather/class-features.js
+++ b/src/features/breather/class-features.js
@@ -29,19 +29,19 @@ export function getRecoverableFeatures(actor) {
       && i.name === config.name
         );
 
-        if (!feature) continue;
+        if (!feature) {continue;}
 
         // Check if feature has uses tracking
         const uses = feature.system.uses;
-        if (!uses || uses.max === null) continue;
+        if (!uses || uses.max === null) {continue;}
 
         // Check if feature is not at max uses
         const currentUses = uses.value ?? 0;
-        if (currentUses >= uses.max) continue;
+        if (currentUses >= uses.max) {continue;}
 
         // Calculate recovery amount
         const recoveryAmount = calculateRecoveryAmount(feature, config.recovery);
-        if (recoveryAmount <= 0) continue;
+        if (recoveryAmount <= 0) {continue;}
 
         // Add to recoverable features
         features.push({
@@ -67,7 +67,7 @@ export function getRecoverableFeatures(actor) {
  */
 export function calculateRecoveryAmount(feature, recoveryType) {
     const uses = feature.system.uses;
-    if (!uses || uses.max === null) return 0;
+    if (!uses || uses.max === null) {return 0;}
 
     const currentUses = uses.value ?? 0;
     const maxUses = uses.max;

--- a/src/features/breather/ui.js
+++ b/src/features/breather/ui.js
@@ -111,10 +111,10 @@ class BreatherUI extends BaseRestDialog {
      */
     #setupFeatureValidation() {
         const form = this.element.querySelector('form');
-        if (!form) return;
+        if (!form) {return;}
 
         const checkboxes = form.querySelectorAll('dnd5e-checkbox[name^="features."]');
-        if (!checkboxes.length) return;
+        if (!checkboxes.length) {return;}
 
         // Validate on any checkbox change
         checkboxes.forEach(checkbox => {
@@ -126,7 +126,7 @@ class BreatherUI extends BaseRestDialog {
         if (rollButton) {
             const originalHandler = rollButton.onclick;
             rollButton.onclick = async event => {
-                if (originalHandler) await originalHandler.call(this, event);
+                if (originalHandler) {await originalHandler.call(this, event);}
                 this.#validateFeatureSelection();
             };
         }
@@ -140,13 +140,13 @@ class BreatherUI extends BaseRestDialog {
      */
     #validateFeatureSelection() {
         const form = this.element.querySelector('form');
-        if (!form) return;
+        if (!form) {return;}
 
         // Count selected features
         const checkboxes = form.querySelectorAll('dnd5e-checkbox[name^="features."]');
         let selectedCount = 0;
         checkboxes.forEach(checkbox => {
-            if (checkbox.checked) selectedCount++;
+            if (checkbox.checked) {selectedCount++;}
         });
 
         // Get available HD

--- a/src/features/encumbrance/encumbrance.js
+++ b/src/features/encumbrance/encumbrance.js
@@ -62,9 +62,9 @@ export function prepareEncumbrance(rollData, { validateItem } = {}) {
             + dnd5e.utils.simplifyBonus(encumbrance.bonuses?.overall, rollData);
         let multiplier = dnd5e.utils.simplifyBonus(encumbrance.multipliers[threshold], rollData)
             * dnd5e.utils.simplifyBonus(encumbrance.multipliers.overall, rollData);
-        if (threshold === 'maximum') maximumMultiplier = multiplier;
-        if (this.parent.type === 'vehicle') base = this.attributes.capacity.cargo;
-        else multiplier *= (config.threshold[threshold]?.[unitSystem] ?? 1) * sizeMod;
+        if (threshold === 'maximum') {maximumMultiplier = multiplier;}
+        if (this.parent.type === 'vehicle') {base = this.attributes.capacity.cargo;}
+        else {multiplier *= (config.threshold[threshold]?.[unitSystem] ?? 1) * sizeMod;}
         return calculateEncumbranceThreshold(base, multiplier, bonus);
     };
 

--- a/src/features/imperiled/actor-updates.js
+++ b/src/features/imperiled/actor-updates.js
@@ -21,7 +21,7 @@ import { showImperiledDialog, applyUnconscious, createImperiledChatMessage } fro
  */
 export async function handleImperiledUpdate(actor, changed, options, userId) {
     // Only process for the user who triggered the update
-    if (game.user.id !== userId) return;
+    if (game.user.id !== userId) {return;}
 
     if (!shouldApplyImperiled(actor.type, actor.prototypeToken.actorLink)) {
         return;

--- a/src/features/imperiled/conditions.js
+++ b/src/features/imperiled/conditions.js
@@ -47,7 +47,7 @@ const addEffect = (effects, {special, ...data}) => {
     data.img = data.icon ?? data.img;
     delete data.icon;
     effects.push(data);
-    if ( special ) CONFIG.specialStatusEffects[special] = data.id;
+    if ( special ) {CONFIG.specialStatusEffects[special] = data.id;}
 };
 
 export function registerImperiledConditions() {

--- a/src/features/imperiled/ui.js
+++ b/src/features/imperiled/ui.js
@@ -30,7 +30,7 @@ export async function showImperiledDialog(exhaustion) {
  * @param {string} reason - Reason for falling unconscious
  */
 export async function applyUnconscious(actor, imperiledEffect, reason = 'falls unconscious and is no longer imperiled') {
-    if (imperiledEffect) await imperiledEffect.delete();
+    if (imperiledEffect) {await imperiledEffect.delete();}
 
     const effect = await ActiveEffect.implementation.fromStatusEffect('unconscious');
     await ActiveEffect.implementation.create(effect, { parent: actor, keepId: true});

--- a/src/features/item-identification/remove-identify.js
+++ b/src/features/item-identification/remove-identify.js
@@ -4,17 +4,17 @@
 export function removeIdentifyButton() {
     // Remove Identify button at top of Item Sheet
     Hooks.on('renderItemSheet5e2', (sheet, [html]) => {
-        if (game.user.isGM) return;
+        if (game.user.isGM) {return;}
         const unidentified = sheet.item.system.identified === false;
-        if (!unidentified) return;
+        if (!unidentified) {return;}
         html.querySelectorAll('.pseudo-header-button.state-toggle.toggle-identified').forEach(n => n.remove());
     });
 
     // Remove Identify button from Item Context menu on Actor Sheet
     Hooks.on('dnd5e.getItemContextOptions', (item, buttons) => {
-        if (game.user.isGM) return;
+        if (game.user.isGM) {return;}
         const unidentified = item.system.identified === false;
-        if (!unidentified) return;
+        if (!unidentified) {return;}
         buttons.findIndex(option => option.name === 'DND5E.Identify');
         buttons.findSplice(e => e.name === 'DND5E.Identify');
     });

--- a/src/features/madness/ui.js
+++ b/src/features/madness/ui.js
@@ -18,7 +18,7 @@ async function addMadnessTracking(app, el, data) {
     }
 
     const statsContainer = el.querySelector('.dnd5e2.sheet.actor .sidebar .stats');
-    if (!statsContainer) return;
+    if (!statsContainer) {return;}
 
     const madnessMax = game.settings.get(module_id, 'madness-max');
     const currentMadness = app.actor.flags?.sosly?.madness ?? 0;

--- a/src/features/multiple-concentration/dialog-modifier.js
+++ b/src/features/multiple-concentration/dialog-modifier.js
@@ -6,14 +6,14 @@
 export function registerDialogModification() {
     Hooks.on('renderActivityUsageDialog', (app, html, data) => {
         const concentrationSection = html.querySelector('section[data-application-part="concentration"]');
-        if (!concentrationSection) return;
+        if (!concentrationSection) {return;}
 
         const select = concentrationSection.querySelector('select[name="concentration.end"]');
-        if (!select) return;
+        if (!select) {return;}
 
         // Find the empty option (value="")
         const emptyOption = select.querySelector('option[value=""]');
-        if (!emptyOption) return;
+        if (!emptyOption) {return;}
 
         // Check if actor has HD available and determine the smallest HD
         const actor = app.actor;

--- a/src/features/multiple-concentration/handler.js
+++ b/src/features/multiple-concentration/handler.js
@@ -22,7 +22,7 @@ export function registerConcentrationHandler() {
 
     // Handle HD expenditure after concentration begins
     Hooks.on('dnd5e.beginConcentrating', async (actor, item, effect, activity) => {
-        if (!pendingMultipleConcentration.get(actor)) return;
+        if (!pendingMultipleConcentration.get(actor)) {return;}
 
         // Clear the pending state
         pendingMultipleConcentration.delete(actor);

--- a/src/features/multiple-concentration/index.js
+++ b/src/features/multiple-concentration/index.js
@@ -49,12 +49,12 @@ export function registerMultipleConcentrationFeature() {
     });
 
     // Only register the rest if enabled
-    if (!isEnabled) return;
+    if (!isEnabled) {return;}
 
     // Set concentration limit for newly created actors
     Hooks.on('preCreateActor', async (actor, data, options, userId) => {
         // Only apply to character and npc types
-        if (data.type !== 'character' && data.type !== 'npc') return;
+        if (data.type !== 'character' && data.type !== 'npc') {return;}
 
         const originalLimit = data.system?.attributes?.concentration?.limit ?? 1;
         await actor.updateSource({

--- a/src/features/networth/ui.js
+++ b/src/features/networth/ui.js
@@ -14,7 +14,7 @@ function addNetworthDisplay(app, el) {
     const networth = calculateNetWorth(app.actor);
     const currencies = el.querySelector('.tab.inventory .middle');
 
-    if (!currencies) return;
+    if (!currencies) {return;}
 
     const networthEl = document.createElement('div');
     networthEl.classList.add('net-worth');

--- a/src/features/psionics/psionics.js
+++ b/src/features/psionics/psionics.js
@@ -53,7 +53,9 @@ function setupPsionicOptions() {
 
 export function registerPsionics() {
     Hooks.once('setup', setupPsionicOptions);
-    Hooks.on('renderActorSheet', addPsionicSubtitles);
-    Hooks.on('renderActorSheet', reorganizePsionicDisciplines);
+    Hooks.on('renderActorSheet5eCharacter2', addPsionicSubtitles);
+    Hooks.on('renderActorSheet5eNPC2', addPsionicSubtitles);
+    Hooks.on('renderActorSheet5eCharacter2', reorganizePsionicDisciplines);
+    Hooks.on('renderActorSheet5eNPC2', reorganizePsionicDisciplines);
     registerPsychicFocusManagement();
 }

--- a/src/features/psionics/psychic-focus.js
+++ b/src/features/psionics/psychic-focus.js
@@ -12,7 +12,7 @@ function isPsychicFocusActivity(activity) {
 
 async function managePsychicFocusEffects(activity) {
     const actor = activity.actor;
-    if (!actor) return;
+    if (!actor) {return;}
 
     logger.info(`Managing effects for actor: ${actor.name}`);
 

--- a/src/features/psionics/ui-features.js
+++ b/src/features/psionics/ui-features.js
@@ -7,7 +7,7 @@ function isPsionicDiscipline(item) {
 
 async function createPsionicDisciplinesSection(html) {
     const featuresSection = html.find('.features-list').first();
-    if (!featuresSection.length) return null;
+    if (!featuresSection.length) {return null;}
 
     const sectionData = {
         label: 'Psionic Disciplines',
@@ -47,18 +47,18 @@ async function createPsionicDisciplinesSection(html) {
 }
 
 export async function reorganizePsionicDisciplines(app, html, data) {
-    if (!data.actor) return;
+    if (!data.actor) {return;}
 
-    if (data.actor.type !== 'character') return;
+    if (data.actor.type !== 'character') {return;}
 
-    if (!html.find('.features-list').length) return;
+    if (!html.find('.features-list').length) {return;}
 
     const psionicDisciplines = data.actor.items.filter(isPsionicDiscipline);
-    if (!psionicDisciplines.length) return;
+    if (!psionicDisciplines.length) {return;}
 
     const otherFeaturesSection = html.find('[data-type="other"]').first();
     const disciplinesSection = await createPsionicDisciplinesSection(html);
-    if (!disciplinesSection) return;
+    if (!disciplinesSection) {return;}
 
     psionicDisciplines
         .sort((a, b) => a.name.localeCompare(b.name))

--- a/src/features/severed-lands-blood-magic/chat-handler.js
+++ b/src/features/severed-lands-blood-magic/chat-handler.js
@@ -9,7 +9,7 @@ export function registerChatHandler() {
     Hooks.on('renderChatMessage', (message, html) => {
         // Only attach listeners to our madness chat cards
         const madnessButton = html.find('[data-action="selectMadness"]');
-        if (madnessButton.length === 0) return;
+        if (madnessButton.length === 0) {return;}
 
         madnessButton.on('click', async event => {
             event.preventDefault();

--- a/src/features/transformation-cleanup/handler.js
+++ b/src/features/transformation-cleanup/handler.js
@@ -2,18 +2,18 @@ import {id as module_id} from '../../../module.json';
 import {logger} from '../../utils/logger';
 
 export function handleTransformationCleanup(actor, options) {
-    if (!game.settings.get(module_id, 'transformation-cleanup')) return;
+    if (!game.settings.get(module_id, 'transformation-cleanup')) {return;}
 
-    if (actor.type !== 'character') return;
+    if (actor.type !== 'character') {return;}
 
-    if (!actor.isPolymorphed) return;
+    if (!actor.isPolymorphed) {return;}
 
-    if (game.user.isGM) return;
+    if (game.user.isGM) {return;}
 
     const previousActorIds = actor.getFlag('dnd5e', 'previousActorIds') ?? [];
     const originalActorId = actor.getFlag('dnd5e', 'originalActor');
 
-    if (!previousActorIds.length) return;
+    if (!previousActorIds.length) {return;}
 
     const actorsToDelete = previousActorIds.filter(id => {
         const tempActor = game.actors.get(id);
@@ -22,7 +22,7 @@ export function handleTransformationCleanup(actor, options) {
 
     const allActorsToDelete = [...actorsToDelete, actor.id];
 
-    if (allActorsToDelete.length === 0) return;
+    if (allActorsToDelete.length === 0) {return;}
 
     setTimeout(async () => {
         try {

--- a/src/features/transformation-cleanup/playwright.js
+++ b/src/features/transformation-cleanup/playwright.js
@@ -58,8 +58,8 @@ test.describe('Transformation Cleanup Feature', () => {
                 isPolymorphed: true,
                 id: 'test-actor-id',
                 getFlag: (module, key) => {
-                    if (key === 'previousActorIds') return ['temp-actor-1', 'temp-actor-2'];
-                    if (key === 'originalActor') return 'original-actor-id';
+                    if (key === 'previousActorIds') {return ['temp-actor-1', 'temp-actor-2'];}
+                    if (key === 'originalActor') {return 'original-actor-id';}
                     return null;
                 }
             };

--- a/src/features/transformation-cleanup/quench.js
+++ b/src/features/transformation-cleanup/quench.js
@@ -86,8 +86,8 @@ export function registerTransformationCleanupTests() {
                     isPolymorphed: true,
                     id: tempActor.id,
                     getFlag: (module, key) => {
-                        if (key === 'previousActorIds') return [tempActor.id];
-                        if (key === 'originalActor') return testActor.id;
+                        if (key === 'previousActorIds') {return [tempActor.id];}
+                        if (key === 'originalActor') {return testActor.id;}
                         return null;
                     }
                 };


### PR DESCRIPTION
# Fix Psionic Power Point Costs Display

Fixes the bug where psionic power point costs were not displaying in spell subtitles on character sheets.

## Changes
- Register hooks on v4-specific sheet renders (`renderActorSheet5eCharacter2` and `renderActorSheet5eNPC2`) instead of generic `renderActorSheet`
- Update power point extraction to identify spell-points items by `system.identifier` instead of hardcoded compendium reference
- Migrate psionic subtitle UI from jQuery to native DOM APIs for consistency with other features
- Add ESLint `curly` rule to enforce braces on all control structures
- Apply curly brace formatting across entire codebase (55 fixes)

## Related Issues
Resolves #67

## Breaking Changes
None