### PR TITLE
Show power point costs on psionic spells in Argon Combat HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add Argon Combat HUD integration for psionic powers displaying power point costs on spell buttons
+
 ### Fixed
 - Fix psionic power point costs not displaying on character sheet spell subtitles by using correct v4 sheet hooks (renderActorSheet5eCharacter2/renderActorSheet5eNPC2)
 - Correct power point extraction to check character's spell-points item instead of compendium reference

--- a/src/features/psionics/psionics.js
+++ b/src/features/psionics/psionics.js
@@ -1,6 +1,7 @@
 import { addPsionicSubtitles } from './ui-spellbook';
 import { reorganizePsionicDisciplines } from './ui-features';
 import { registerPsychicFocusManagement } from './psychic-focus';
+import { registerArgonIntegration } from './ui-argon';
 
 function setupPsionicOptions() {
     CONFIG.DND5E.featureTypes.discipline = {
@@ -58,4 +59,5 @@ export function registerPsionics() {
     Hooks.on('renderActorSheet5eCharacter2', reorganizePsionicDisciplines);
     Hooks.on('renderActorSheet5eNPC2', reorganizePsionicDisciplines);
     registerPsychicFocusManagement();
+    registerArgonIntegration();
 }

--- a/src/features/psionics/ui-argon.js
+++ b/src/features/psionics/ui-argon.js
@@ -1,0 +1,86 @@
+import { PSIONIC_SCHOOLS } from './ui-spellbook';
+
+function isPsionicSpell(spell) {
+    return spell.system.level === 99 && PSIONIC_SCHOOLS.includes(spell.system.school);
+}
+
+function getPowerPointCostRange(spell, actor) {
+    if (!spell.system.activities) {
+        return null;
+    }
+
+    const powerPointsItems = actor.items.filter(item => item.system.identifier === 'spell-points');
+    if (!powerPointsItems.length) {
+        return null;
+    }
+
+    const powerPointsIds = new Set(powerPointsItems.map(item => item.id));
+
+    const costs = [];
+    for (const activity of spell.system.activities) {
+        if (!activity.consumption?.targets) {
+            continue;
+        }
+
+        for (const target of activity.consumption.targets) {
+            if (target.type === 'itemUses' && powerPointsIds.has(target.target)) {
+                const cost = parseInt(target.value);
+                if (!isNaN(cost)) {
+                    costs.push(cost);
+                }
+            }
+        }
+    }
+
+    if (costs.length === 0) {
+        return null;
+    }
+
+    const minCost = Math.min(...costs);
+    const maxCost = Math.max(...costs);
+
+    if (minCost === maxCost) {
+        return `${minCost}`;
+    }
+    return `${minCost}-${maxCost}`;
+}
+
+function updatePsionicButtonQuantities(component, element, actor) {
+    if (!actor) {
+        return;
+    }
+
+    const buttons = element.querySelectorAll('.feature-element');
+    for (const button of buttons) {
+        const img = button.style.backgroundImage;
+        if (!img) {
+            continue;
+        }
+
+        const imgUrl = img.slice(5, -2);
+        const item = actor.items.find(i => i.img === imgUrl);
+        if (!item || !isPsionicSpell(item)) {
+            continue;
+        }
+
+        const costRange = getPowerPointCostRange(item, actor);
+        if (costRange === null) {
+            continue;
+        }
+
+        const quantitySpan = button.querySelector('.quantity-1 span');
+        if (!quantitySpan) {
+            continue;
+        }
+
+        quantitySpan.innerHTML = `<span class="psionic-cost">${costRange}</span>`;
+    }
+}
+
+export function registerArgonIntegration() {
+    if (!game.modules.get('enhancedcombathud')?.active) {
+        return;
+    }
+
+    Hooks.on('renderAccordionPanelCategoryArgonComponent', updatePsionicButtonQuantities);
+}

--- a/src/features/psionics/ui-spellbook.js
+++ b/src/features/psionics/ui-spellbook.js
@@ -1,4 +1,39 @@
-const PSIONIC_SCHOOLS = ['ava', 'awa', 'imm', 'nom', 'sok', 'wuj'];
+export const PSIONIC_SCHOOLS = ['ava', 'awa', 'imm', 'nom', 'sok', 'wuj'];
+
+export function getMinimumPowerPointCost(spell, actor) {
+    if (!spell.system.activities) {
+        return null;
+    }
+
+    const powerPointsItems = actor.items.filter(item => item.system.identifier === 'spell-points');
+    if (!powerPointsItems.length) {
+        return null;
+    }
+
+    const powerPointsIds = new Set(powerPointsItems.map(item => item.id));
+
+    const costs = [];
+    for (const activity of spell.system.activities) {
+        if (!activity.consumption?.targets) {
+            continue;
+        }
+
+        for (const target of activity.consumption.targets) {
+            if (target.type === 'itemUses' && powerPointsIds.has(target.target)) {
+                const cost = parseInt(target.value);
+                if (!isNaN(cost)) {
+                    costs.push(cost);
+                }
+            }
+        }
+    }
+
+    if (costs.length === 0) {
+        return null;
+    }
+
+    return Math.min(...costs);
+}
 
 function extractPowerPointCosts(spell, actor) {
     if (!spell.system.activities) {

--- a/src/styles/features/_psionics.scss
+++ b/src/styles/features/_psionics.scss
@@ -1,0 +1,11 @@
+// Psionics feature styles
+
+.extended-combat-hud .action-hud .quantity-1:has(.psionic-cost) {
+    justify-content: flex-start;
+}
+
+.psionic-cost {
+    font-size: 0.8em;
+    white-space: nowrap;
+    padding-left: 0.25em;
+}

--- a/src/styles/house-rules.scss
+++ b/src/styles/house-rules.scss
@@ -15,6 +15,7 @@
 @use 'features/location';
 @use 'features/madness';
 @use 'features/networth';
+@use 'features/psionics';
 
 // System fixes and overrides
 @use 'fixes';


### PR DESCRIPTION
# Show power point costs on psionic spells in Argon Combat HUD

Integrates with Argon Combat HUD to display the minimum power point cost on each psionic spell button, replacing the previous behavior of showing the total remaining power point pool.

## Changes
- Add Argon Combat HUD integration module that hooks into button rendering
- Display single-cost powers as the exact cost (e.g., "3")
- Display variable-cost powers as a range (e.g., "1-7")
- Extract shared utility function for calculating minimum power point costs
- Add custom styling for psionic cost display with proper font sizing and left alignment
- Gracefully handle cases where Argon is not installed (no errors)

## Related Issues
Resolves #64

## Breaking Changes
None