### PR TITLE
Add Psionicist Manifesting Card to Character Sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Argon Combat HUD integration for psionic powers with separate "Manifest Power" button, power point costs display, and discipline-based grouping
 - Display actual power point pool (e.g., "6/84 power points") in Argon Combat HUD discipline groups instead of individual slot boxes
 - Filter psionic powers based on character's Power Limit in both Spellbook UI and Argon Combat HUD, hiding powers with minimum power point costs exceeding the current limit
+- Add Psionicist Manifesting card to character sheet spellbook displaying Power Limit, ability modifier, attack bonus, and save DC
 
 ### Fixed
 - Fix psionic power point costs not displaying on character sheet spell subtitles by using correct v4 sheet hooks (renderActorSheet5eCharacter2/renderActorSheet5eNPC2)

--- a/src/features/psionics/psionics.js
+++ b/src/features/psionics/psionics.js
@@ -2,6 +2,7 @@ import { addPsionicSubtitles } from './ui-spellbook';
 import { reorganizePsionicDisciplines } from './ui-features';
 import { registerPsychicFocusManagement } from './psychic-focus';
 import { registerArgonIntegration } from './ui-argon';
+import { injectPsionicistManifestingCard } from './ui-spellbook-card';
 
 function setupPsionicOptions() {
     CONFIG.DND5E.featureTypes.discipline = {
@@ -58,6 +59,8 @@ export function registerPsionics() {
     Hooks.on('renderActorSheet5eNPC2', addPsionicSubtitles);
     Hooks.on('renderActorSheet5eCharacter2', reorganizePsionicDisciplines);
     Hooks.on('renderActorSheet5eNPC2', reorganizePsionicDisciplines);
+    Hooks.on('renderActorSheet5eCharacter2', injectPsionicistManifestingCard);
+    Hooks.on('renderActorSheet5eNPC2', injectPsionicistManifestingCard);
     registerPsychicFocusManagement();
     registerArgonIntegration();
 }

--- a/src/features/psionics/ui-spellbook-card.js
+++ b/src/features/psionics/ui-spellbook-card.js
@@ -1,0 +1,48 @@
+import { getPowerLimit } from './ui-spellbook';
+
+/**
+ * @param {Application} app
+ * @param {jQuery} html
+ * @param {object} context
+ */
+export async function injectPsionicistManifestingCard(app, html, context) {
+    if (!context.actor) {
+        return;
+    }
+
+    const psionicistClass = context.actor.classes?.psionicist;
+    if (!psionicistClass) {
+        return;
+    }
+
+    const intMod = context.actor.system.abilities.int.mod;
+    const profBonus = context.actor.system.attributes.prof;
+    const powerLimit = getPowerLimit(context.actor);
+
+    if (powerLimit === null) {
+        return;
+    }
+
+    const el = html[0];
+    const topSection = el.querySelector('.spells .top');
+    if (!topSection) {
+        return;
+    }
+
+    const attack = intMod + profBonus;
+    const save = 8 + intMod + profBonus;
+
+    const templateData = {
+        powerLimit,
+        abilityMod: `${intMod >= 0 ? '+' : ''}${intMod}`,
+        attackBonus: `${attack >= 0 ? '+' : ''}${attack}`,
+        saveDC: save
+    };
+
+    const cardHTML = await renderTemplate(
+        'modules/sosly-5e-house-rules/templates/features/psionics/manifesting-card.hbs',
+        templateData
+    );
+
+    topSection.insertAdjacentHTML('beforeend', cardHTML);
+}

--- a/templates/features/psionics/manifesting-card.hbs
+++ b/templates/features/psionics/manifesting-card.hbs
@@ -1,6 +1,7 @@
-<div class="spellcasting card" data-ability="int">
+<div class="spellcasting card" data-ability="{{abilityId}}">
     <div class="header">
         <h3>Psionicist Manifesting</h3>
+        <button type="button" class="radio-button" data-action="spellcasting" data-tooltip="DND5E.SpellAbilitySet" aria-pressed="{{#if isPrimary}}true{{else}}false{{/if}}" aria-label="Set as Primary Spellcasting Ability"></button>
     </div>
     <div class="info">
         <div class="limit">

--- a/templates/features/psionics/manifesting-card.hbs
+++ b/templates/features/psionics/manifesting-card.hbs
@@ -1,0 +1,23 @@
+<div class="spellcasting card" data-ability="int">
+    <div class="header">
+        <h3>Psionicist Manifesting</h3>
+    </div>
+    <div class="info">
+        <div class="limit">
+            <span class="label">Limit</span>
+            <span class="value">{{powerLimit}}</span>
+        </div>
+        <div class="ability">
+            <span class="label">Ability</span>
+            <span class="value">{{abilityMod}}</span>
+        </div>
+        <div class="attack">
+            <span class="label">Attack</span>
+            <span class="value">{{attackBonus}}</span>
+        </div>
+        <div class="save">
+            <span class="label">Save DC</span>
+            <span class="value">{{saveDC}}</span>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
# Add Psionicist Manifesting Card to Character Sheet

Adds a manifesting statistics card to the character sheet spellbook for Psionicist characters, displaying Power Limit, ability modifier, attack bonus, and save DC. This complements the existing Argon Combat HUD integration and provides essential psionics information directly on the standard character sheet.

## Changes

- Add Psionicist Manifesting card to character sheet spellbook displaying Power Limit, ability modifier, attack bonus, and save DC
- Display actual power point pool in Argon Combat HUD discipline groups (e.g., "6/84 power points")
- Add Argon Combat HUD integration with separate "Manifest Power" button and discipline-based grouping
- Filter psionic powers based on character's Power Limit in both Spellbook UI and Argon Combat HUD
- Fix psionic power point costs display on character sheets using correct v4 sheet hooks
- Correct power point extraction to check character's spell-points item instead of compendium reference
- Migrate psionics UI from jQuery to native DOM APIs
- Extract duplicate power point item lookup logic into reusable utility function
- Enforce curly braces for all control structures with new ESLint rule
- Migrate psionics manifesting card to Handlebars template following project conventions

## Related Issues

Resolves #80

## Breaking Changes

None