### PR TITLE
fix: migrate legacy compendium item data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
     "type": "module",
     "scripts": {
+        "audit:packs": "node ./tools/audit_pack_migrations.mjs",
         "build": "npm run lint:code && npm run build:code && npm run build:packs && npm run build:styles",
         "build:code": "npx rollup --config rollup.config.mjs",
-        "build:packs": "node ./tools/convert_yaml_to_ldb.mjs",
+        "build:packs": "npm run audit:packs && node ./tools/convert_yaml_to_ldb.mjs",
         "build:styles": "sass src/styles/house-rules.scss:dist/house-rules.css --style compressed",
         "clean": "del-cli dist packs",
         "compose:packs": "node ./tools/convert_ldb_to_yaml.mjs",

--- a/src/packs/classes/feat_Power_Points_yXFJ10Lf7yDyu5OM.yml
+++ b/src/packs/classes/feat_Power_Points_yXFJ10Lf7yDyu5OM.yml
@@ -52,7 +52,6 @@ flags:
     riders:
       activity: []
       effect: []
-    migratedUses: 1
 _stats:
   compendiumSource: null
   duplicateSource: null

--- a/src/packs/classes/feat_Strain_y5ubVYWLa9PBBVMC.yml
+++ b/src/packs/classes/feat_Strain_y5ubVYWLa9PBBVMC.yml
@@ -67,7 +67,6 @@ flags:
     riders:
       activity: []
       effect: []
-    migratedUses: 1
 _stats:
   compendiumSource: null
   duplicateSource: null

--- a/src/packs/extra-spells/spell_Create_Bonfire_88NSbkNTscV2ebIK.yml
+++ b/src/packs/extra-spells/spell_Create_Bonfire_88NSbkNTscV2ebIK.yml
@@ -177,11 +177,6 @@ flags:
     depth: null
     environment: ''
   dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
-      - concentration
     riders:
       activity: []
       effect: []

--- a/src/packs/extra-spells/spell_Distort_Value_Jd1OUzBOqvHAaTZV.yml
+++ b/src/packs/extra-spells/spell_Distort_Value_Jd1OUzBOqvHAaTZV.yml
@@ -130,10 +130,6 @@ flags:
   cf:
     id: temp_ag8qdr5hh9i
   core: {}
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
 img: icons/commodities/currency/coin-engraved-sun-smile-copper.webp
 effects: []
 _stats:

--- a/src/packs/extra-spells/spell_Fluid_Funds_Sho7k4WQMflsXVlR.yml
+++ b/src/packs/extra-spells/spell_Fluid_Funds_Sho7k4WQMflsXVlR.yml
@@ -96,6 +96,7 @@ system:
   identifier: fluid-funds
   properties:
     - vocal
+    - somatic
     - material
     - ritual
 effects: []
@@ -140,12 +141,6 @@ flags:
     id: temp_fgrqfjce6mm
   scene-packer:
     sourceId: Compendium.sosly.spells.Item.v2HE7kEyhujkoDvV
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - somatic
-      - material
-      - ritual
 _stats:
   compendiumSource: null
   duplicateSource: null

--- a/src/packs/extra-spells/spell_Life_Transference_zvADcJpPR78iglOL.yml
+++ b/src/packs/extra-spells/spell_Life_Transference_zvADcJpPR78iglOL.yml
@@ -162,9 +162,6 @@ flags:
       value: true
       altValue: true
   dnd5e:
-    migratedProperties:
-      - vocal
-      - somatic
     riders:
       activity: []
       effect: []

--- a/src/packs/extra-spells/spell_Shadow_Blade_SJbtyqVY3Hth8dE3.yml
+++ b/src/packs/extra-spells/spell_Shadow_Blade_SJbtyqVY3Hth8dE3.yml
@@ -129,11 +129,6 @@ flags:
     id: temp_3jaisgztlwn
   core: {}
   dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
-      - concentration
     riders:
       activity: []
       effect: []

--- a/src/packs/extra-spells/spell_Thunder_Step_1yldSZSng0mZ0Cy0.yml
+++ b/src/packs/extra-spells/spell_Thunder_Step_1yldSZSng0mZ0Cy0.yml
@@ -162,8 +162,6 @@ flags:
   core:
     sourceId: Compendium.sosly.spells.Item.2jrzJrMEEEVx40Z4
   dnd5e:
-    migratedProperties:
-      - vocal
     riders:
       activity: []
       effect: []

--- a/src/packs/monsters/npc_Hobgoblin_Devastator_u9QWQ76SoYXNoao7.yml
+++ b/src/packs/monsters/npc_Hobgoblin_Devastator_u9QWQ76SoYXNoao7.yml
@@ -2070,11 +2070,6 @@ items:
         id: temp_3jaisgztlwn
       core: {}
       dnd5e:
-        persistSourceMigration: true
-        migratedProperties:
-          - vocal
-          - somatic
-          - material
         riders:
           activity: []
           effect: []
@@ -2228,11 +2223,6 @@ items:
       cf:
         id: temp_3jaisgztlwn
       core: {}
-      dnd5e:
-        persistSourceMigration: true
-        migratedProperties:
-          - vocal
-          - somatic
     img: icons/magic/water/vortex-water-whirlpool-blue.webp
     effects: []
     _stats:
@@ -2540,10 +2530,6 @@ items:
         id: temp_3jaisgztlwn
       core: {}
       dnd5e:
-        persistSourceMigration: true
-        migratedProperties:
-          - vocal
-          - concentration
         riders:
           activity: []
           effect: []
@@ -3164,10 +3150,6 @@ items:
       cf:
         id: temp_ag8qdr5hh9i
       core: {}
-      dnd5e:
-        persistSourceMigration: true
-        migratedProperties:
-          - vocal
     img: icons/magic/control/energy-stream-link-white.webp
     effects: []
     _stats:
@@ -3384,7 +3366,44 @@ items:
       preparation:
         mode: prepared
         prepared: true
-      activities: {}
+      activities:
+        GL5SXAAT01xu8Nu6:
+          _id: GL5SXAAT01xu8Nu6
+          type: utility
+          name: Cast
+          activation:
+            type: action
+            value: null
+            override: false
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description: {}
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          range:
+            units: self
+            override: false
+          target:
+            template:
+              contiguous: false
+              units: ft
+            affects:
+              choice: false
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+          roll:
+            prompt: false
+            visible: false
+          sort: 0
       identifier: encode-thoughts
       properties:
         - somatic
@@ -3418,9 +3437,6 @@ items:
         id: temp_swxucta6r2
       core: {}
       dnd5e:
-        persistSourceMigration: true
-        migratedProperties:
-          - somatic
         riders:
           activity: []
           effect: []
@@ -3621,11 +3637,6 @@ items:
         depth: null
         environment: ''
       dnd5e:
-        persistSourceMigration: true
-        migratedProperties:
-          - vocal
-          - somatic
-          - concentration
         riders:
           activity: []
           effect: []

--- a/src/packs/spells/spell_Air_Blast_LFTtcPDcPFcL7oAX.yml
+++ b/src/packs/spells/spell_Air_Blast_LFTtcPDcPFcL7oAX.yml
@@ -167,11 +167,6 @@ flags:
     id: temp_sch38kntbfe
   scene-packer:
     sourceId: Compendium.sosly.spells.Item.LFTtcPDcPFcL7oAX
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
 _stats:
   compendiumSource: Compendium.sosly-5e-house-rules.spells.Item.LFTtcPDcPFcL7oAX
   duplicateSource: null

--- a/src/packs/spells/spell_Alter_Self_JVr7Jy0qxg5nX1hA.yml
+++ b/src/packs/spells/spell_Alter_Self_JVr7Jy0qxg5nX1hA.yml
@@ -141,12 +141,6 @@ flags:
       value: true
       altValue: true
   core: {}
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
-      - concentration
 img: icons/magic/control/silhouette-hold-change-green.webp
 effects: []
 _stats:

--- a/src/packs/spells/spell_Amaneusis_4th83KV4A8V3P3mw.yml
+++ b/src/packs/spells/spell_Amaneusis_4th83KV4A8V3P3mw.yml
@@ -92,6 +92,7 @@ system:
         visible: false
   identifier: amaneusis
   properties:
+    - vocal
     - somatic
     - material
     - ritual
@@ -138,11 +139,6 @@ flags:
   scene-packer:
     sourceId: Compendium.sosly.spells.Item.O1AYPiaFIlTg2tua
   dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - material
-      - ritual
     riders:
       activity: []
       effect: []

--- a/src/packs/spells/spell_Annoying_Bee_VlY62bccECT7B1Rt.yml
+++ b/src/packs/spells/spell_Annoying_Bee_VlY62bccECT7B1Rt.yml
@@ -226,11 +226,6 @@ flags:
     id: temp_9ykd9r1nsxt
   scene-packer:
     sourceId: Compendium.sosly.spells.Item.VlY62bccECT7B1Rt
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
 _stats:
   compendiumSource: Compendium.sosly-5e-house-rules.spells.Item.VlY62bccECT7B1Rt
   duplicateSource: null

--- a/src/packs/spells/spell_Avendi_Spirit_Bond_BUSJ6SdE9QZOra0g.yml
+++ b/src/packs/spells/spell_Avendi_Spirit_Bond_BUSJ6SdE9QZOra0g.yml
@@ -4,7 +4,43 @@ type: spell
 _id: BUSJ6SdE9QZOra0g
 img: icons/magic/nature/wolf-paw-glow-teal-blue.webp
 system:
-  activities: {}
+  activities:
+    avendiSpiritBond:
+      _id: avendiSpiritBond
+      type: utility
+      name: Bond
+      activation:
+        type: action
+        value: null
+        override: false
+      consumption:
+        scaling:
+          allowed: false
+        spellSlot: true
+        targets: []
+      description: {}
+      duration:
+        units: inst
+        concentration: false
+        override: false
+      effects: []
+      range:
+        override: false
+      target:
+        template:
+          contiguous: false
+          units: ft
+        affects:
+          choice: false
+        override: false
+        prompt: true
+      uses:
+        spent: 0
+        recovery: []
+      roll:
+        prompt: false
+        visible: false
+      sort: 0
   uses:
     spent: 0
     recovery: []

--- a/src/packs/spells/spell_Beast_Growth_54y3Ck3c8wWVaDvk.yml
+++ b/src/packs/spells/spell_Beast_Growth_54y3Ck3c8wWVaDvk.yml
@@ -98,6 +98,7 @@ system:
     - vocal
     - somatic
     - material
+    - ritual
 effects: []
 flags:
   scene-packer:
@@ -119,13 +120,6 @@ flags:
   core: {}
   cf:
     id: temp_9ykd9r1nsxt
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
-      - material
-      - ritual
 _stats:
   compendiumSource: null
   duplicateSource: null

--- a/src/packs/spells/spell_Command_Jli7fh1SUNhFFKyd.yml
+++ b/src/packs/spells/spell_Command_Jli7fh1SUNhFFKyd.yml
@@ -176,9 +176,6 @@ flags:
       altValue: true
   core: {}
   dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
     riders:
       activity: []
       effect: []

--- a/src/packs/spells/spell_Comrades__Succor_h8v6i5deqr8Tb2Ij.yml
+++ b/src/packs/spells/spell_Comrades__Succor_h8v6i5deqr8Tb2Ij.yml
@@ -98,6 +98,7 @@ system:
   identifier: comrades-succor
   properties:
     - vocal
+    - somatic
     - material
     - ritual
 effects: []
@@ -143,12 +144,6 @@ flags:
   scene-packer:
     sourceId: Compendium.sosly.spells.Item.HcOigiij4o38OEJR
   dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
-      - material
-      - ritual
     riders:
       activity: []
       effect: []

--- a/src/packs/spells/spell_Darklight_GiyIuVJHPVydP9sG.yml
+++ b/src/packs/spells/spell_Darklight_GiyIuVJHPVydP9sG.yml
@@ -97,6 +97,7 @@ system:
   properties:
     - vocal
     - somatic
+    - concentration
 effects: []
 flags:
   scene-packer:
@@ -118,12 +119,6 @@ flags:
   core: {}
   cf:
     id: temp_sch38kntbfe
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
-      - concentration
 _stats:
   compendiumSource: null
   duplicateSource: null

--- a/src/packs/spells/spell_Dazzle_NpyqERtGWSynIOo7.yml
+++ b/src/packs/spells/spell_Dazzle_NpyqERtGWSynIOo7.yml
@@ -223,10 +223,6 @@ flags:
   scene-packer:
     hash: eb476a5363ea5a4c886fc1c171810f6b7f864c97
     sourceId: Compendium.sosly.spells.Item.NpyqERtGWSynIOo7
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - somatic
 _stats:
   compendiumSource: Compendium.sosly-5e-house-rules.spells.Item.NpyqERtGWSynIOo7
   duplicateSource: null

--- a/src/packs/spells/spell_Earthen_Grasp_jReEhUAAjh4W2t0B.yml
+++ b/src/packs/spells/spell_Earthen_Grasp_jReEhUAAjh4W2t0B.yml
@@ -146,9 +146,6 @@ flags:
     id: temp_swxucta6r2
   core: {}
   dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
     riders:
       activity: []
       effect: []

--- a/src/packs/spells/spell_Encode_Thoughts_xLWkUHnvqzfDFr7h.yml
+++ b/src/packs/spells/spell_Encode_Thoughts_xLWkUHnvqzfDFr7h.yml
@@ -58,7 +58,44 @@ system:
   preparation:
     mode: always
     prepared: false
-  activities: {}
+  activities:
+    GL5SXAAT01xu8Nu6:
+      _id: GL5SXAAT01xu8Nu6
+      type: utility
+      name: Cast
+      activation:
+        type: action
+        value: null
+        override: false
+      consumption:
+        scaling:
+          allowed: false
+        spellSlot: true
+        targets: []
+      description: {}
+      duration:
+        units: inst
+        concentration: false
+        override: false
+      effects: []
+      range:
+        units: self
+        override: false
+      target:
+        template:
+          contiguous: false
+          units: ft
+        affects:
+          choice: false
+        override: false
+        prompt: true
+      uses:
+        spent: 0
+        recovery: []
+      roll:
+        prompt: false
+        visible: false
+      sort: 0
   identifier: encode-thoughts
   properties:
     - somatic
@@ -92,9 +129,6 @@ flags:
     id: temp_swxucta6r2
   core: {}
   dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - somatic
     riders:
       activity: []
       effect: []

--- a/src/packs/spells/spell_Goodberry_xBYl9MLuNY5afkf1.yml
+++ b/src/packs/spells/spell_Goodberry_xBYl9MLuNY5afkf1.yml
@@ -154,12 +154,6 @@ flags:
     references: []
   scene-packer:
     sourceId: Compendium.sosly.spells.Item.QZPMWIBpt4IOHngC
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
-      - material
 img: icons/consumables/fruit/berries-hanging-red.webp
 effects: []
 _stats:

--- a/src/packs/spells/spell_Grease_1mxPKdVO0XP0nn2D.yml
+++ b/src/packs/spells/spell_Grease_1mxPKdVO0XP0nn2D.yml
@@ -134,12 +134,6 @@ flags:
   cf:
     id: temp_ag8qdr5hh9i
   core: {}
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
-      - material
 img: icons/magic/air/fog-gas-smoke-orange.webp
 effects: []
 _stats:

--- a/src/packs/spells/spell_Jolt_O5dRxnOTVuJRQ7Ly.yml
+++ b/src/packs/spells/spell_Jolt_O5dRxnOTVuJRQ7Ly.yml
@@ -193,10 +193,6 @@ flags:
   scene-packer:
     sourceId: Compendium.sosly.spells.Item.GG6uZIcyCmp7cPey
   dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
     riders:
       activity: []
       effect: []

--- a/src/packs/spells/spell_Larloch_s_Minor_Drain_5UX2UAAc5pwlcsMo.yml
+++ b/src/packs/spells/spell_Larloch_s_Minor_Drain_5UX2UAAc5pwlcsMo.yml
@@ -151,11 +151,6 @@ flags:
   core: {}
   cf:
     id: temp_9ykd9r1nsxt
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
 _stats:
   compendiumSource: null
   duplicateSource: null

--- a/src/packs/spells/spell_Snare_kx8BnIKjcM0VQv7a.yml
+++ b/src/packs/spells/spell_Snare_kx8BnIKjcM0VQv7a.yml
@@ -153,11 +153,6 @@ flags:
       value: true
       altValue: true
   core: {}
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - somatic
-      - material
 img: icons/sundries/survival/rope-wrapped-purple.webp
 effects: []
 _stats:

--- a/src/packs/spells/spell_Sunlit_Blade_qUtYsX9zWWrR9ogc.yml
+++ b/src/packs/spells/spell_Sunlit_Blade_qUtYsX9zWWrR9ogc.yml
@@ -251,10 +251,6 @@ flags:
     hash: 63eee9375dc20fd931e4e55a0bbf0c31bafde258
     sourceId: Compendium.sosly.spells.Item.epb9RGQvwcruQBlf
   dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - somatic
-      - material
     riders:
       activity: []
       effect: []

--- a/src/packs/spells/spell_Wall_of_Gloom_SMkDSFO09jxl1vnR.yml
+++ b/src/packs/spells/spell_Wall_of_Gloom_SMkDSFO09jxl1vnR.yml
@@ -107,6 +107,7 @@ system:
     - vocal
     - somatic
     - material
+    - concentration
 img: icons/magic/air/fog-gas-smoke-gray.webp
 effects: []
 flags:
@@ -133,13 +134,6 @@ flags:
       altValue: true
   scene-packer:
     sourceId: Compendium.sosly.spells.Item.Dgp2vwSLuNwcBDJN
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
-      - material
-      - concentration
 _stats:
   compendiumSource: null
   duplicateSource: null

--- a/src/packs/spells/spell_Ward_of_Silence_nBbXiLQBd3JZ2AWL.yml
+++ b/src/packs/spells/spell_Ward_of_Silence_nBbXiLQBd3JZ2AWL.yml
@@ -97,6 +97,7 @@ system:
   properties:
     - vocal
     - somatic
+    - ritual
 effects: []
 flags:
   scene-packer:
@@ -123,12 +124,6 @@ flags:
   core: {}
   cf:
     id: temp_fgrqfjce6mm
-  dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
-      - ritual
 _stats:
   compendiumSource: null
   duplicateSource: null

--- a/src/packs/spells/spell_Wither_and_Bloom_fuqU4kfVqPXwmlnG.yml
+++ b/src/packs/spells/spell_Wither_and_Bloom_fuqU4kfVqPXwmlnG.yml
@@ -120,7 +120,10 @@ system:
       img: ''
       appliedEffects: []
   identifier: wither-and-bloom
-  properties: []
+  properties:
+    - vocal
+    - somatic
+    - material
 name: Wither and Bloom
 flags:
   ddbimporter:
@@ -179,11 +182,6 @@ flags:
     references: []
   core: {}
   dnd5e:
-    persistSourceMigration: true
-    migratedProperties:
-      - vocal
-      - somatic
-      - material
     riders:
       activity: []
       effect: []

--- a/tools/audit_pack_migrations.mjs
+++ b/tools/audit_pack_migrations.mjs
@@ -1,0 +1,92 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { loadAll } from 'js-yaml';
+
+const PACK_SOURCE = path.resolve('src/packs');
+const TRANSIENT_FLAGS = [
+    'persistSourceMigration',
+    'migratedProperties',
+    'migratedUses'
+];
+
+const yamlFiles = await findYamlFiles(PACK_SOURCE);
+const failures = [];
+let itemCount = 0;
+
+for (const file of yamlFiles) {
+    const documents = [];
+    loadAll(await fs.readFile(file, 'utf8'), document => documents.push(document));
+
+    for (const document of documents) {
+        for (const item of getItems(document)) {
+            itemCount += 1;
+            auditItem(item, file, document);
+        }
+    }
+}
+
+if (failures.length > 0) {
+    console.error(`Pack migration audit failed with ${failures.length} problem(s):`);
+    for (const failure of failures) {
+        console.error(`- ${failure}`);
+    }
+    process.exitCode = 1;
+} else {
+    console.log(`Pack migration audit passed for ${itemCount} Items in ${yamlFiles.length} YAML files.`);
+}
+
+async function findYamlFiles(directory) {
+    const files = [];
+
+    for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+        const entryPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...await findYamlFiles(entryPath));
+            continue;
+        }
+        if (entry.name.endsWith('.yml') || entry.name.endsWith('.yaml')) {
+            files.push(entryPath);
+        }
+    }
+
+    return files.sort();
+}
+
+function getItems(document) {
+    if (!document || typeof document !== 'object') {
+        return [];
+    }
+
+    const documentKey = String(document._key ?? '');
+    if (documentKey.startsWith('!items!')) {
+        return [document];
+    }
+    if (documentKey.startsWith('!actors!')) {
+        return document.items ?? [];
+    }
+
+    return [];
+}
+
+function auditItem(item, file, parent) {
+    const location = formatLocation(item, file, parent);
+    const dnd5eFlags = item.flags?.dnd5e ?? {};
+
+    for (const flag of TRANSIENT_FLAGS) {
+        if (Object.hasOwn(dnd5eFlags, flag)) {
+            failures.push(`${location} retains flags.dnd5e.${flag}`);
+        }
+    }
+
+    const activationType = item.system?.activation?.type;
+    const activities = item.system?.activities ?? {};
+    if (item.type === 'spell' && activationType && Object.keys(activities).length === 0) {
+        failures.push(`${location} has ${activationType} activation without an activity`);
+    }
+}
+
+function formatLocation(item, file, parent) {
+    const relativeFile = path.relative(PACK_SOURCE, file).replaceAll(path.sep, '/');
+    const parentName = String(parent?._key ?? '').startsWith('!actors!') ? ` in ${parent.name}` : '';
+    return `${relativeFile}: ${item.name} (${item._id})${parentName}`;
+}


### PR DESCRIPTION
## Summary

- migrate retained dnd5e spell metadata into current item properties
- remove transient compendium migration flags and add the three missing spell activities
- audit all pack YAML before each pack build to prevent recurrence

## Validation

- `npm run audit:packs`
- two consecutive `npm run build:packs` runs with no additional source changes
- `npm run build`
- Foundry v13 build 350 / dnd5e 5.2.5 live validation on port 30000 as both Gamemaster and Player2
- confirmed Wither and Bloom displays V, S, M for both users
- confirmed Encode Thoughts exposes Cast and Avendi Spirit Bond exposes Bond