### PR TITLE
fix: clear stale low-light polygon on mode change

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "test:integration": "playwright test",
         "test:integration:headed": "playwright test --headed",
         "test:integration:ui": "playwright test --ui",
-        "test:unit": "node --test src/features/low-light-vision/light-union-cache.test.js",
+        "test:unit": "node --test src/features/low-light-vision/light-union-cache.test.js src/features/low-light-vision/vision-source-polygons.test.js",
         "watch": "npm-run-all --parallel watch:*",
         "watch:code": "npm-watch build:code",
         "watch:lint": "npm-watch lint:code",

--- a/src/features/low-light-vision/index.js
+++ b/src/features/low-light-vision/index.js
@@ -78,6 +78,7 @@ function patchVisionSourcePolygons() {
         const original = originalCreateLightPolygon.call(this);
 
         if (this.visionMode?.id !== 'lowLight') {
+            this._lowLightExtendedPolygon = null;
             return original;
         }
 

--- a/src/features/low-light-vision/vision-source-polygons.test.js
+++ b/src/features/low-light-vision/vision-source-polygons.test.js
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {fileURLToPath} from 'node:url';
+
+import json from '@rollup/plugin-json';
+import {rollup} from 'rollup';
+
+const PointVisionSource = await installVisionSourcePolygonPatch();
+
+test('clears an obsolete extension when the current low-light calculation has no result', () => {
+    const originalLight = {id: 'original-light'};
+    const originalRestricted = {id: 'original-restricted'};
+    const obsoleteExtension = {id: 'obsolete-extension'};
+    const source = new PointVisionSource('lowLight', originalLight, originalRestricted);
+    source._lowLightExtendedPolygon = obsoleteExtension;
+
+    assert.equal(source._createLightPolygon(), originalLight);
+    assert.equal(source._lowLightExtendedPolygon, null);
+    assert.equal(source._createRestrictedPolygon(), originalRestricted);
+});
+
+test('clears the stored extension when the source leaves low-light mode', () => {
+    const originalLight = {id: 'original-light'};
+    const originalRestricted = {id: 'original-restricted'};
+    const obsoleteExtension = {id: 'obsolete-extension'};
+    const source = new PointVisionSource('basic', originalLight, originalRestricted);
+    source._lowLightExtendedPolygon = obsoleteExtension;
+
+    assert.equal(source._createLightPolygon(), originalLight);
+    assert.equal(source._lowLightExtendedPolygon, null);
+    assert.equal(source._createRestrictedPolygon(), originalRestricted);
+});
+
+test('cannot restore an obsolete extension after returning to low-light mode', () => {
+    const originalLight = {id: 'original-light'};
+    const originalRestricted = {id: 'original-restricted'};
+    const obsoleteExtension = {id: 'obsolete-extension'};
+    const source = new PointVisionSource('basic', originalLight, originalRestricted);
+    source._lowLightExtendedPolygon = obsoleteExtension;
+
+    source._createLightPolygon();
+    source.visionMode = {id: 'lowLight'};
+
+    assert.equal(source._createRestrictedPolygon(), originalRestricted);
+});
+
+async function installVisionSourcePolygonPatch() {
+    let setupHook;
+
+    class TestPointVisionSource {
+        constructor(mode, originalLight, originalRestricted) {
+            this.visionMode = {id: mode};
+            this.originalLight = originalLight;
+            this.originalRestricted = originalRestricted;
+        }
+
+        _createLightPolygon() {
+            return this.originalLight;
+        }
+
+        _createRestrictedPolygon() {
+            return this.originalRestricted;
+        }
+    }
+
+    class VisionMode {}
+    VisionMode.LIGHTING_VISIBILITY = {REQUIRED: 'required'};
+
+    globalThis.foundry = {
+        canvas: {
+            perception: {VisionMode},
+            sources: {PointVisionSource: TestPointVisionSource}
+        }
+    };
+    globalThis.game = {
+        settings: {
+            get(moduleId, setting) {
+                return setting === 'low-light-vision' ? true : 2;
+            },
+            register() {}
+        }
+    };
+    globalThis.Hooks = {
+        on() {},
+        once(event, callback) {
+            if (event === 'setup') {
+                setupHook = callback;
+            }
+        }
+    };
+    globalThis.CONFIG = {
+        Canvas: {
+            detectionModes: {
+                lightPerception: {
+                    _testPoint() {
+                        return false;
+                    }
+                }
+            },
+            visionModes: {}
+        }
+    };
+    globalThis.canvas = {effects: {lightSources: null, visionSources: []}};
+    globalThis.requestAnimationFrame = () => 1;
+    globalThis.cancelAnimationFrame = () => {};
+
+    const bundle = await rollup({
+        input: fileURLToPath(new URL('./index.js', import.meta.url)),
+        plugins: [json()]
+    });
+    const {output} = await bundle.generate({format: 'es'});
+    await bundle.close();
+
+    const encodedModule = Buffer.from(output[0].code).toString('base64');
+    const lowLightVision = await import(`data:text/javascript;base64,${encodedModule}`);
+    lowLightVision.registerLowLightVisionFeature();
+    setupHook();
+
+    return TestPointVisionSource;
+}


### PR DESCRIPTION
## Summary
- Clear the retained low-light extension when a vision source leaves low-light mode.
- Add regression coverage for an empty recalculation, mode exit, and low-light re-entry.

## Validation
- npm run test:unit: 8 passed
- npm run lint:code: 0 errors; 1 pre-existing unrelated warning
- npm run build:code
- Live Foundry 13.350 and dnd5e 5.2.5 validation at port 30000