### PR TITLE
Fix idempotent Breather button injection

### DIFF
--- a/src/features/breather/breather.js
+++ b/src/features/breather/breather.js
@@ -127,6 +127,10 @@ export class Breather {
             return;
         }
 
+        if (buttons.querySelector('.breather-button')) {
+            return;
+        }
+
         const button = document.createElement('button');
         button.type = 'button';
         button.classList.add('breather-button', 'gold-button');

--- a/src/features/breather/playwright.js
+++ b/src/features/breather/playwright.js
@@ -485,4 +485,84 @@ test.describe('Breather', () => {
         const layStillVisible = dialog.locator('dnd5e-checkbox[name="features.lay-on-hands"]');
         await expect(layStillVisible).toBeVisible();
     });
+
+    test('repeated partial renders keep one functional button', async ({ page }) => {
+        const actorIds = [
+            await createActor(page, 'Breather Idempotence Character', 'character'),
+            await createActor(page, 'Breather Idempotence NPC', 'npc')
+        ];
+
+        const results = await page.evaluate(async ids => {
+            const delay = ms => new Promise(resolve => {
+                setTimeout(resolve, ms);
+            });
+            const actorResults = [];
+
+            for (const id of ids) {
+                const actor = game.actors.get(id);
+                const app = actor.sheet;
+                let actionCalls = 0;
+                const hookId = Hooks.on('sosly.preBreather', breatherActor => {
+                    if (breatherActor === actor) {
+                        actionCalls++;
+                        return false;
+                    }
+                });
+
+                try {
+                    app.render({force: true});
+                    await delay(800);
+
+                    const initialHeader = app.element.querySelector('.sheet-header-buttons');
+                    const initialButtonCount = initialHeader.querySelectorAll('.breather-button').length;
+
+                    for (let i = 0; i < 20; i++) {
+                        app.render({parts: ['features']});
+                        await delay(100);
+                    }
+
+                    const partialHeader = app.element.querySelector('.sheet-header-buttons');
+                    const partialButtonCount = partialHeader.querySelectorAll('.breather-button').length;
+                    partialHeader.querySelector('.breather-button').click();
+                    await delay(100);
+                    const partialRenderActionCalls = actionCalls;
+
+                    app.render({force: true});
+                    await delay(800);
+
+                    const replacementHeader = app.element.querySelector('.sheet-header-buttons');
+                    const replacementButtonCount = replacementHeader.querySelectorAll('.breather-button').length;
+                    replacementHeader.querySelector('.breather-button').click();
+                    await delay(100);
+
+                    actorResults.push({
+                        type: actor.type,
+                        initialButtonCount,
+                        partialHeaderPreserved: partialHeader === initialHeader,
+                        partialButtonCount,
+                        partialRenderActionCalls,
+                        headerReplaced: replacementHeader !== initialHeader,
+                        replacementButtonCount,
+                        replacementActionCalls: actionCalls
+                    });
+                } finally {
+                    Hooks.off('sosly.preBreather', hookId);
+                    await app.close();
+                }
+            }
+
+            return actorResults;
+        }, actorIds);
+
+        expect(results.map(result => result.type)).toEqual(['character', 'npc']);
+        for (const result of results) {
+            expect(result.initialButtonCount).toBe(1);
+            expect(result.partialHeaderPreserved).toBe(true);
+            expect(result.partialButtonCount).toBe(1);
+            expect(result.partialRenderActionCalls).toBe(1);
+            expect(result.headerReplaced).toBe(true);
+            expect(result.replacementButtonCount).toBe(1);
+            expect(result.replacementActionCalls).toBe(2);
+        }
+    });
 });


### PR DESCRIPTION
Fixes F-05 by skipping Breather button injection when the current sheet header already contains the module button. Adds character and NPC regression coverage for repeated partial renders, one-action click behavior, and replacement headers. Validation: JavaScript lint completed with only the pre-existing unused _feature warning; the code build passed; all 8 unit tests passed; and live Foundry 13.350 with dnd5e 5.2.5 kept one button through 20 partial renders on Player2-owned character and NPC sheets, invoked one action per click, and restored one button after a forced full render. The existing Playwright runner remains blocked before test discovery under Node 22 by its JSON import configuration.