### PR TITLE
Fix Net Worth render idempotency

### DIFF
--- a/src/features/networth/playwright.js
+++ b/src/features/networth/playwright.js
@@ -1,0 +1,114 @@
+import {expect, test} from '@playwright/test';
+import {createActor, loginUser} from '../../testing/foundry-helpers.js';
+
+const LOCATION_TYPE = 'sosly-5e-house-rules.location';
+
+test.describe('Net Worth display', () => {
+    test.beforeEach(async ({page}) => {
+        await loginUser(page, 'Gamemaster');
+    });
+
+    test('reconciles the current display across supported sheet renders', async ({page}) => {
+        const actorIds = [
+            await createActor(page, 'Net Worth Character', 'character', {
+                system: {currency: {gp: 5}}
+            }),
+            await createActor(page, 'Net Worth NPC', 'npc', {
+                system: {currency: {gp: 5}}
+            }),
+            await createActor(page, 'Net Worth Location', LOCATION_TYPE, {
+                system: {currency: {gp: 5}}
+            })
+        ];
+
+        try {
+            const results = await page.evaluate(async actorIds => {
+                const delay = ms => new Promise(resolve => {
+                    setTimeout(resolve, ms);
+                });
+                const hookByType = {
+                    character: 'renderCharacterActorSheet',
+                    npc: 'renderNPCActorSheet',
+                    'sosly-5e-house-rules.location': 'renderLocationSheet'
+                };
+                const actorResults = [];
+
+                for (const actorId of actorIds) {
+                    const actor = game.actors.get(actorId);
+                    const app = actor.sheet;
+                    const hook = hookByType[actor.type];
+
+                    try {
+                        app.render({force: true});
+                        await delay(800);
+
+                        const initialContainer = app.element.querySelector('.inventory-element .currency');
+                        const initialDisplay = initialContainer.querySelector('.net-worth');
+
+                        for (let index = 0; index < 20; index++) {
+                            Hooks.callAll(hook, app, app.element, {}, {});
+                        }
+
+                        const afterStressDisplays = initialContainer.querySelectorAll('.net-worth');
+
+                        actor.updateSource({'system.currency.gp': 17});
+                        Hooks.callAll(hook, app, app.element, {}, {});
+
+                        const updatedDisplays = initialContainer.querySelectorAll('.net-worth');
+                        const updatedDisplay = updatedDisplays[0];
+
+                        app.render({force: true});
+                        await delay(800);
+
+                        const replacementContainer = app.element.querySelector('.inventory-element .currency');
+                        const replacementDisplays = replacementContainer.querySelectorAll('.net-worth');
+                        const replacementDisplay = replacementDisplays[0];
+
+                        actorResults.push({
+                            type: actor.type,
+                            initialCount: initialContainer.querySelectorAll('.net-worth').length,
+                            stressCount: afterStressDisplays.length,
+                            updatedCount: updatedDisplays.length,
+                            reusedDisplay: updatedDisplay === initialDisplay,
+                            updatedValue: updatedDisplay.querySelector('span').textContent,
+                            containerReplaced: replacementContainer !== initialContainer,
+                            replacementCount: replacementDisplays.length,
+                            replacementValue: replacementDisplay.querySelector('span').textContent,
+                            iconClasses: Array.from(replacementDisplay.querySelector('i').classList),
+                            tooltip: replacementDisplay.querySelector('i').dataset.tooltip,
+                            ariaLabel: replacementDisplay.querySelector('i').getAttribute('aria-label')
+                        });
+                    } finally {
+                        await app.close();
+                    }
+                }
+
+                return actorResults;
+            }, actorIds);
+
+            expect(results.map(result => result.type)).toEqual([
+                'character',
+                'npc',
+                LOCATION_TYPE
+            ]);
+
+            for (const result of results) {
+                expect(result.initialCount).toBe(1);
+                expect(result.stressCount).toBe(1);
+                expect(result.updatedCount).toBe(1);
+                expect(result.reusedDisplay).toBe(true);
+                expect(result.updatedValue).toBe('17');
+                expect(result.containerReplaced).toBe(true);
+                expect(result.replacementCount).toBe(1);
+                expect(result.replacementValue).toBe('17');
+                expect(result.iconClasses).toEqual(['fas', 'fa-coins']);
+                expect(result.tooltip).toBe('sosly.networth');
+                expect(result.ariaLabel).toBe('Net Worth');
+            }
+        } finally {
+            for (const actorId of actorIds) {
+                await page.evaluate(async actorId => game.actors.get(actorId)?.delete(), actorId);
+            }
+        }
+    });
+});

--- a/src/features/networth/ui.js
+++ b/src/features/networth/ui.js
@@ -5,19 +5,9 @@
 
 import { calculateNetWorth } from './calculator';
 
-/**
- * Add net worth display to character sheet
- * @param {Application} app - The sheet application
- * @param {HTMLElement} el - The sheet HTML element
- */
-function addNetworthDisplay(app, el) {
-    const networth = calculateNetWorth(app.actor);
-    const currencies = el.querySelector('.inventory-element .currency');
+const NET_WORTH_SELECTOR = ':scope > .net-worth';
 
-    if (!currencies) {
-        return;
-    }
-
+function createNetworthDisplay() {
     const networthEl = document.createElement('div');
     networthEl.classList.add('net-worth');
 
@@ -27,12 +17,37 @@ function addNetworthDisplay(app, el) {
     icon.setAttribute('aria-label', 'Net Worth');
 
     const content = document.createElement('span');
-    content.textContent = networth.toLocaleString();
 
     networthEl.appendChild(icon);
     networthEl.appendChild(content);
 
-    currencies.appendChild(networthEl);
+    return networthEl;
+}
+
+/**
+ * Add net worth display to character sheet
+ * @param {Application} app - The sheet application
+ * @param {HTMLElement} el - The sheet HTML element
+ */
+function addNetworthDisplay(app, el) {
+    const currencies = el.querySelector('.inventory-element .currency');
+
+    if (!currencies) {
+        return;
+    }
+
+    const displays = currencies.querySelectorAll(NET_WORTH_SELECTOR);
+    const networthEl = displays[0] ?? createNetworthDisplay();
+
+    for (const duplicate of Array.from(displays).slice(1)) {
+        duplicate.remove();
+    }
+
+    networthEl.querySelector('span').textContent = calculateNetWorth(app.actor).toLocaleString();
+
+    if (networthEl.parentElement !== currencies) {
+        currencies.appendChild(networthEl);
+    }
 }
 
 /**


### PR DESCRIPTION
Makes the Net Worth render-hook integration reconcile one module-owned display per currency container, update its current value, remove accumulated duplicates, and create a fresh display after container replacement. Adds a live Playwright regression for Character, NPC, and Location sheets. Validation: ESLint completed with no errors and one unrelated existing warning; code bundle built successfully; focused Playwright regression passed; live Gamemaster stress and Player2 display checks passed on Foundry 13.350 with dnd5e 5.2.5. The F-07 Repair checkbox remains unchecked pending manual validation.