### PR TITLE
fix: reconcile the blood pool meter on sheet renders

### DIFF
--- a/src/features/severed-lands-blood-magic/playwright.js
+++ b/src/features/severed-lands-blood-magic/playwright.js
@@ -1,0 +1,281 @@
+import {expect, test} from '@playwright/test';
+import {createActor, loginUser} from '../../testing/foundry-helpers.js';
+
+const module_id = 'sosly-5e-house-rules';
+
+test.describe('Severed Lands blood pool meter', () => {
+    test.beforeEach(async ({page}) => {
+        await loginUser(page, 'Gamemaster');
+    });
+
+    test('partial renders reconcile one current functional meter', async ({page}) => {
+        const actorId = await createActor(page, 'Blood Meter Character');
+        const originalActorId = await createActor(page, 'Blood Meter Original Character');
+
+        const results = await page.evaluate(async ({actorId, originalActorId, moduleId}) => {
+            const delay = ms => new Promise(resolve => {
+                setTimeout(resolve, ms);
+            });
+            const actor = game.actors.get(actorId);
+            const originalActor = game.actors.get(originalActorId);
+            const originalEnabled = game.settings.get(moduleId, 'severed-lands-blood-magic');
+            const [firstVial, secondVial] = await actor.createEmbeddedDocuments('Item', [
+                {
+                    name: 'Playwright Blood Vial A',
+                    type: 'feat',
+                    system: {
+                        identifier: 'blood-vial',
+                        uses: {max: 30, spent: 6}
+                    }
+                },
+                {
+                    name: 'Playwright Blood Vial B',
+                    type: 'feat',
+                    system: {
+                        identifier: 'blood-vial',
+                        uses: {max: 18, spent: 6}
+                    }
+                }
+            ]);
+            await originalActor.createEmbeddedDocuments('Item', [{
+                name: 'Playwright Original Blood Vial',
+                type: 'feat',
+                system: {
+                    identifier: 'blood-vial',
+                    uses: {max: 40, spent: 10}
+                }
+            }]);
+
+            const app = actor.sheet;
+            const trackedItemUpdates = [];
+            let empoweredBloodUpdates = 0;
+            const itemHookId = Hooks.on('preUpdateItem', (item, changes) => {
+                if (item.parent === actor && foundry.utils.hasProperty(changes, 'system.uses.spent')) {
+                    trackedItemUpdates.push(item.id);
+                }
+            });
+            const actorHookId = Hooks.on('preUpdateActor', (updatedActor, changes) => {
+                if (updatedActor === actor
+                    && foundry.utils.hasProperty(changes, `flags.${moduleId}.empoweredBlood`)) {
+                    empoweredBloodUpdates++;
+                }
+            });
+            const summarize = () => {
+                const sidebar = app.element?.querySelector('.dnd5e2.sheet.actor .sidebar .stats');
+                const groups = sidebar?.querySelectorAll('[data-sosly-meter="blood-pool"]') ?? [];
+                const meter = groups[0]?.querySelector('.meter.blood-pool');
+                return {
+                    sidebar,
+                    groupCount: groups.length,
+                    value: meter?.getAttribute('aria-valuenow'),
+                    max: meter?.getAttribute('aria-valuemax')
+                };
+            };
+            const renderPartial = async () => {
+                app.render({parts: ['inventory']});
+                await delay(250);
+            };
+            const editMeter = async value => {
+                const group = app.element.querySelector('[data-sosly-meter="blood-pool"]');
+                const label = group?.querySelector('.meter.blood-pool .label');
+                const input = group?.querySelector('.meter.blood-pool input');
+                if (!label || !input) {
+                    throw new Error('Blood pool meter was not inline editable');
+                }
+
+                label.click();
+                input.value = String(value);
+                input.blur();
+                await delay(800);
+            };
+
+            try {
+                await game.settings.set(moduleId, 'severed-lands-blood-magic', true);
+                app.render({force: true, mode: app.constructor.MODES.EDIT});
+                await delay(1000);
+                const initial = summarize();
+
+                for (let index = 0; index < 20; index++) {
+                    await renderPartial();
+                }
+                const repeated = summarize();
+
+                await editMeter(25);
+                const edited = summarize();
+                const distributedTotal = actor.items
+                    .filter(item => item.system.identifier === 'blood-vial')
+                    .reduce((total, item) => total + item.system.uses.max - item.system.uses.spent, 0);
+                const editUpdatedItems = [...new Set(trackedItemUpdates)].sort();
+                const editUpdateCount = trackedItemUpdates.length;
+
+                const [thirdVial] = await actor.createEmbeddedDocuments('Item', [{
+                    name: 'Playwright Blood Vial C',
+                    type: 'feat',
+                    system: {
+                        identifier: 'blood-vial',
+                        uses: {max: 12, spent: 2}
+                    }
+                }]);
+                await renderPartial();
+                const afterAdd = summarize();
+
+                await thirdVial.update({'system.uses.max': 20, 'system.uses.spent': 4});
+                await renderPartial();
+                const afterChange = summarize();
+
+                await thirdVial.delete();
+                await renderPartial();
+                const afterRemove = summarize();
+
+                await actor.update({
+                    'flags.dnd5e.isPolymorphed': true,
+                    'flags.dnd5e.originalActor': originalActorId,
+                    [`flags.${moduleId}.empoweredBlood`]: 55
+                });
+                empoweredBloodUpdates = 0;
+                await renderPartial();
+                const polymorphed = summarize();
+
+                for (let index = 0; index < 20; index++) {
+                    app.render({parts: ['inventory']});
+                }
+                await delay(1000);
+                const overlapping = summarize();
+
+                await editMeter(50);
+                const polymorphEdit = summarize();
+
+                await actor.update({'flags.dnd5e.originalActor': 'missing-actor'});
+                await renderPartial();
+                const missingOriginal = summarize();
+
+                await actor.update({'flags.dnd5e.isPolymorphed': false});
+                await renderPartial();
+                const reverted = summarize();
+
+                await actor.deleteEmbeddedDocuments('Item', [firstVial.id, secondVial.id]);
+                await renderPartial();
+                const noVials = summarize();
+
+                await actor.createEmbeddedDocuments('Item', [{
+                    name: 'Playwright Replacement Blood Vial',
+                    type: 'feat',
+                    system: {
+                        identifier: 'blood-vial',
+                        uses: {max: 15, spent: 3}
+                    }
+                }]);
+                await renderPartial();
+                const restored = summarize();
+
+                await game.settings.set(moduleId, 'severed-lands-blood-magic', false);
+                const enabledSidebar = restored.sidebar;
+                await renderPartial();
+                const disabled = summarize();
+
+                return {
+                    initial: {
+                        groupCount: initial.groupCount,
+                        value: initial.value,
+                        max: initial.max
+                    },
+                    repeated: {
+                        sameSidebar: repeated.sidebar === initial.sidebar,
+                        groupCount: repeated.groupCount,
+                        value: repeated.value,
+                        max: repeated.max
+                    },
+                    edit: {
+                        groupCount: edited.groupCount,
+                        value: edited.value,
+                        distributedTotal,
+                        updatedItems: editUpdatedItems,
+                        updateCount: editUpdateCount
+                    },
+                    afterAdd: {
+                        groupCount: afterAdd.groupCount,
+                        value: afterAdd.value,
+                        max: afterAdd.max
+                    },
+                    afterChange: {
+                        groupCount: afterChange.groupCount,
+                        value: afterChange.value,
+                        max: afterChange.max
+                    },
+                    afterRemove: {
+                        groupCount: afterRemove.groupCount,
+                        value: afterRemove.value,
+                        max: afterRemove.max
+                    },
+                    polymorphed: {
+                        groupCount: polymorphed.groupCount,
+                        value: polymorphed.value,
+                        max: polymorphed.max
+                    },
+                    overlapping: {
+                        groupCount: overlapping.groupCount,
+                        value: overlapping.value,
+                        max: overlapping.max
+                    },
+                    polymorphEdit: {
+                        groupCount: polymorphEdit.groupCount,
+                        value: polymorphEdit.value,
+                        flagValue: actor.getFlag(moduleId, 'empoweredBlood'),
+                        updateCount: empoweredBloodUpdates
+                    },
+                    missingOriginal: {
+                        groupCount: missingOriginal.groupCount
+                    },
+                    reverted: {
+                        groupCount: reverted.groupCount,
+                        value: reverted.value,
+                        max: reverted.max
+                    },
+                    noVials: {
+                        groupCount: noVials.groupCount
+                    },
+                    restored: {
+                        groupCount: restored.groupCount,
+                        value: restored.value,
+                        max: restored.max
+                    },
+                    disabled: {
+                        sameSidebar: disabled.sidebar === enabledSidebar,
+                        groupCount: disabled.groupCount
+                    }
+                };
+            } finally {
+                Hooks.off('preUpdateItem', itemHookId);
+                Hooks.off('preUpdateActor', actorHookId);
+                await app.close();
+                await actor.delete();
+                await originalActor.delete();
+                await game.settings.set(moduleId, 'severed-lands-blood-magic', originalEnabled);
+            }
+        }, {actorId, originalActorId, moduleId: module_id});
+
+        expect(results.initial).toEqual({groupCount: 1, value: '36', max: '48'});
+        expect(results.repeated).toEqual({sameSidebar: true, groupCount: 1, value: '36', max: '48'});
+        expect(results.edit.groupCount).toBe(1);
+        expect(results.edit.value).toBe('25');
+        expect(results.edit.distributedTotal).toBe(25);
+        expect(results.edit.updatedItems).toHaveLength(2);
+        expect(results.edit.updateCount).toBe(2);
+        expect(results.afterAdd).toEqual({groupCount: 1, value: '35', max: '60'});
+        expect(results.afterChange).toEqual({groupCount: 1, value: '41', max: '68'});
+        expect(results.afterRemove).toEqual({groupCount: 1, value: '25', max: '48'});
+        expect(results.polymorphed).toEqual({groupCount: 1, value: '55', max: '80'});
+        expect(results.overlapping).toEqual({groupCount: 1, value: '55', max: '80'});
+        expect(results.polymorphEdit).toEqual({
+            groupCount: 1,
+            value: '50',
+            flagValue: 50,
+            updateCount: 1
+        });
+        expect(results.missingOriginal).toEqual({groupCount: 0});
+        expect(results.reverted).toEqual({groupCount: 1, value: '25', max: '48'});
+        expect(results.noVials).toEqual({groupCount: 0});
+        expect(results.restored).toEqual({groupCount: 1, value: '12', max: '15'});
+        expect(results.disabled).toEqual({sameSidebar: true, groupCount: 0});
+    });
+});

--- a/src/features/severed-lands-blood-magic/ui.js
+++ b/src/features/severed-lands-blood-magic/ui.js
@@ -2,6 +2,14 @@ import {id as module_id} from '../../../module.json';
 import { createMeter } from '../../components/meters/meter.js';
 
 const BLOOD_VIAL_IDENTIFIER = 'blood-vial';
+const BLOOD_METER_SELECTOR = '[data-sosly-meter="blood-pool"]';
+const bloodRenderTokens = new WeakMap();
+
+function removeBloodMeters(element) {
+    for (const meter of element.querySelectorAll(BLOOD_METER_SELECTOR)) {
+        meter.remove();
+    }
+}
 
 function calculateBloodPool(actor) {
     const bloodVials = actor.items.filter(item => item.system.identifier === BLOOD_VIAL_IDENTIFIER);
@@ -73,32 +81,23 @@ async function distributeBloodAcrossVials(actor, newTotal) {
     }
 }
 
-async function addBloodTracking(app, element, context) {
-    if (!game.settings.get(module_id, 'severed-lands-blood-magic')) {
-        return;
-    }
-
-    const statsContainer = element.querySelector('.dnd5e2.sheet.actor .sidebar .stats');
-    if (!statsContainer) {
-        return;
-    }
-
+async function createBloodMeter(app) {
     if (app.actor.isPolymorphed) {
         const originalActorId = app.actor.getFlag('dnd5e', 'originalActor');
         const originalActor = game.actors.get(originalActorId);
 
         if (!originalActor) {
-            return;
+            return null;
         }
 
         const bloodPool = calculateBloodPool(originalActor);
         if (!bloodPool) {
-            return;
+            return null;
         }
 
         const empoweredBlood = app.actor.getFlag(module_id, 'empoweredBlood') ?? bloodPool.current;
 
-        const meterResult = await createMeter({
+        return createMeter({
             label: game.i18n.localize('sosly.severedLandsBloodMagic.bloodPool'),
             valueNow: empoweredBlood,
             valueMax: bloodPool.max * 2,
@@ -110,23 +109,14 @@ async function addBloodTracking(app, element, context) {
                 await app.actor.setFlag(module_id, 'empoweredBlood', newValue);
             }
         });
-
-        const meterElement = document.createElement('div');
-        meterElement.innerHTML = meterResult.html;
-        const meterGroup = meterElement.firstElementChild;
-
-        meterResult.setup(meterGroup);
-
-        statsContainer.appendChild(meterGroup);
-        return;
     }
 
     const bloodPool = calculateBloodPool(app.actor);
     if (!bloodPool) {
-        return;
+        return null;
     }
 
-    const meterResult = await createMeter({
+    return createMeter({
         label: game.i18n.localize('sosly.severedLandsBloodMagic.bloodPool'),
         valueNow: bloodPool.current,
         valueMax: bloodPool.max,
@@ -138,14 +128,47 @@ async function addBloodTracking(app, element, context) {
             await distributeBloodAcrossVials(app.actor, newValue);
         }
     });
+}
+
+async function addBloodTracking(app, element) {
+    const renderToken = Symbol('blood-pool-render');
+    bloodRenderTokens.set(app, renderToken);
+
+    if (!game.settings.get(module_id, 'severed-lands-blood-magic')) {
+        removeBloodMeters(element);
+        return;
+    }
+
+    const statsContainer = element.querySelector('.dnd5e2.sheet.actor .sidebar .stats');
+    if (!statsContainer) {
+        return;
+    }
+
+    const meterResult = await createBloodMeter(app);
+
+    if (bloodRenderTokens.get(app) !== renderToken) {
+        return;
+    }
+
+    if (!game.settings.get(module_id, 'severed-lands-blood-magic') || !meterResult) {
+        removeBloodMeters(element);
+        return;
+    }
+
+    const currentStatsContainer = element.querySelector('.dnd5e2.sheet.actor .sidebar .stats');
+    if (!currentStatsContainer) {
+        return;
+    }
 
     const meterElement = document.createElement('div');
     meterElement.innerHTML = meterResult.html;
     const meterGroup = meterElement.firstElementChild;
 
+    meterGroup.setAttribute('data-sosly-meter', 'blood-pool');
     meterResult.setup(meterGroup);
 
-    statsContainer.appendChild(meterGroup);
+    removeBloodMeters(element);
+    currentStatsContainer.appendChild(meterGroup);
 }
 
 async function handleTransform(original, source, transformedData, settings, options) {
@@ -193,11 +216,11 @@ async function handleRevert(transformedActor, options) {
 
 export function registerBloodMagicHooks() {
     Hooks.on('renderCharacterActorSheet', async (app, element, context, options) => {
-        await addBloodTracking(app, element, context);
+        await addBloodTracking(app, element);
     });
 
     Hooks.on('renderNPCActorSheet', async (app, element, context, options) => {
-        await addBloodTracking(app, element, context);
+        await addBloodTracking(app, element);
     });
 
     Hooks.on('dnd5e.transformActorV2', handleTransform);


### PR DESCRIPTION
## Summary
- reconcile the blood-pool meter instead of appending on every sheet hook
- discard stale async render completions so the latest sheet state wins
- remove the owned meter when the feature, blood vials, or original polymorph actor is unavailable
- add Foundry regression coverage for repeated and overlapping renders, edits, vial changes, transitions, and removal paths

## Validation
- focused Playwright regression passed against Foundry 13.350 and dnd5e 5.2.5
- `npm run test:unit` (8 passed)
- `npm run lint` (0 errors; one pre-existing warning in `src/features/breather/breather.js`)
- visible browser validation retained exactly one `48 / 90` meter after 20 partial sheet renders

## Scope
The separate formula-backed `uses.max` calculation defect documented in F-08 is intentionally not changed by this PR.