### PR TITLE
Fix psionic manifesting card rendering

### DIFF
--- a/src/features/psionics/playwright.js
+++ b/src/features/psionics/playwright.js
@@ -1,0 +1,360 @@
+import { expect, test } from '@playwright/test';
+import { loginUser } from '../../testing/foundry-helpers.js';
+
+const CARD_SELECTOR = '[data-sosly-card="psionic-manifesting"]';
+const CLASS_ID = 'RZUGlaJPnjd23lWC';
+const CLASSES_PACK = 'sosly-5e-house-rules.classes';
+
+async function createPsionicActor(page, type, ownerName = null) {
+    return page.evaluate(async ({ actorType, classId, packId, actorOwnerName }) => {
+        const actorSource = {
+            name: `Playwright F-09 ${actorType}`,
+            type: actorType,
+            system: {
+                abilities: {
+                    int: { value: 18 }
+                },
+                attributes: {
+                    spellcasting: 'wis'
+                }
+            }
+        };
+        if (actorOwnerName) {
+            const owner = game.users.getName(actorOwnerName);
+            actorSource.ownership = {
+                default: CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE,
+                [owner.id]: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER
+            };
+        }
+
+        const actor = await Actor.create(actorSource);
+        const psionicist = await game.packs.get(packId).getDocument(classId);
+        const classSource = psionicist.toObject();
+        delete classSource._id;
+        classSource.system.advancement = classSource.system.advancement.filter(
+            advancement => advancement.type === 'ScaleValue'
+        );
+        const [classItem] = await actor.createEmbeddedDocuments('Item', [classSource]);
+
+        return { actorId: actor.id, classItemId: classItem.id };
+    }, {
+        actorType: type,
+        classId: CLASS_ID,
+        packId: CLASSES_PACK,
+        actorOwnerName: ownerName
+    });
+}
+
+async function validatePsionicActor(page, fixture, type) {
+    return page.evaluate(async ({ actorId, classItemId, actorType, cardSelector }) => {
+        const actor = game.actors.get(actorId);
+        const app = actor.sheet;
+        const renderHook = `render${actorType === 'character' ? 'Character' : 'NPC'}ActorSheet`;
+        const delay = ms => new Promise(resolve => {
+            setTimeout(resolve, ms);
+        });
+        const waitFor = async predicate => {
+            for (let attempt = 0; attempt < 50; attempt++) {
+                if (predicate()) {
+                    return;
+                }
+                await delay(100);
+            }
+            throw new Error(`Timed out waiting for ${actorType} sheet state`);
+        };
+        const getTopSection = () => app.element?.querySelector('[data-application-part="spells"] > .top');
+        const getCards = () => Array.from(app.element?.querySelectorAll(cardSelector) ?? []);
+        const summarizeCard = () => {
+            const card = getCards()[0];
+            return {
+                cardCount: getCards().length,
+                ability: card?.querySelector('.ability .value')?.textContent.trim(),
+                attack: card?.querySelector('.attack .value')?.textContent.trim(),
+                save: card?.querySelector('.save .value')?.textContent.trim(),
+                limit: card?.querySelector('.limit .value')?.textContent.trim(),
+                primary: card?.querySelector('button[data-action="spellcasting"]')?.getAttribute('aria-pressed')
+            };
+        };
+
+        let renderHookCalls = 0;
+        let spellcastingUpdates = 0;
+        const renderHookId = Hooks.on(renderHook, renderedApp => {
+            if (renderedApp === app) {
+                renderHookCalls++;
+            }
+        });
+        const updateHookId = Hooks.on('preUpdateActor', (updatedActor, changes) => {
+            if (updatedActor === actor && foundry.utils.hasProperty(changes, 'system.attributes.spellcasting')) {
+                spellcastingUpdates++;
+            }
+        });
+
+        try {
+            app.render({ force: true, mode: app.constructor.MODES.EDIT });
+            await waitFor(() => getCards().length === 1);
+            await delay(500);
+
+            const initialTopSection = getTopSection();
+            const initialCard = getCards()[0];
+            const initial = {
+                directTopSections: app.element.querySelectorAll('[data-application-part="spells"] > .top').length,
+                obsoleteSelectorMatches: app.element.querySelectorAll('.spells .top').length,
+                ...summarizeCard()
+            };
+
+            renderHookCalls = 0;
+            for (let iteration = 0; iteration < 20; iteration++) {
+                app.render({ parts: ['sidebar'] });
+            }
+            await waitFor(() => renderHookCalls >= 20);
+            await waitFor(() => getCards().length === 1);
+            const partial = {
+                hookCalls: renderHookCalls,
+                sameTopSection: getTopSection() === initialTopSection,
+                cardReplaced: getCards()[0] !== initialCard,
+                ...summarizeCard()
+            };
+
+            const topBeforeReplacement = getTopSection();
+            app.render({ parts: ['spells'] });
+            await waitFor(() => getTopSection() !== topBeforeReplacement && getCards().length === 1);
+            const replacement = {
+                topSectionReplaced: getTopSection() !== topBeforeReplacement,
+                ...summarizeCard()
+            };
+
+            await actor.update({ 'system.abilities.int.value': 20 });
+            await waitFor(() => summarizeCard().ability === '+5');
+            const currentValues = summarizeCard();
+
+            const nativeCard = document.createElement('div');
+            nativeCard.className = 'spellcasting card';
+            nativeCard.dataset.ability = 'int';
+            nativeCard.innerHTML = '<button type="button" data-action="spellcasting">Native</button>';
+            getTopSection().prepend(nativeCard);
+            const nativeButton = nativeCard.querySelector('button');
+
+            renderHookCalls = 0;
+            for (let iteration = 0; iteration < 20; iteration++) {
+                app.render({ parts: ['sidebar'] });
+            }
+            await waitFor(() => renderHookCalls >= 20);
+            await waitFor(() => getCards().length === 1);
+
+            nativeButton.click();
+            await delay(200);
+            const updatesAfterNativeClick = spellcastingUpdates;
+
+            getCards()[0].querySelector('button[data-action="spellcasting"]').click();
+            await waitFor(() => actor.system.attributes.spellcasting === 'int');
+            await waitFor(() => summarizeCard().primary === 'true');
+            const listener = {
+                updatesAfterNativeClick,
+                updatesAfterModuleClick: spellcastingUpdates,
+                actorSpellcasting: actor.system.attributes.spellcasting,
+                moduleCardCount: getCards().length,
+                primary: summarizeCard().primary
+            };
+
+            const topBeforeFullRender = getTopSection();
+            app.render({ force: true });
+            await waitFor(() => getTopSection() !== topBeforeFullRender && getCards().length === 1);
+            const fullRender = {
+                topSectionReplaced: getTopSection() !== topBeforeFullRender,
+                ...summarizeCard()
+            };
+
+            const classItem = actor.items.get(classItemId);
+            if (actorType === 'character') {
+                await actor.deleteEmbeddedDocuments('Item', [classItemId]);
+            } else {
+                const advancements = classItem.toObject().system.advancement.filter(
+                    advancement => advancement.title !== 'Power Limit'
+                );
+                await classItem.update({ 'system.advancement': advancements });
+            }
+            app.render({ parts: ['inventory'] });
+            await waitFor(() => getCards().length === 0);
+
+            return {
+                initial,
+                partial,
+                replacement,
+                currentValues,
+                listener,
+                fullRender,
+                cardCountAfterEligibilityRemoval: getCards().length
+            };
+        } finally {
+            Hooks.off(renderHook, renderHookId);
+            Hooks.off('preUpdateActor', updateHookId);
+            await app.close();
+            await actor.delete();
+        }
+    }, {
+        actorId: fixture.actorId,
+        classItemId: fixture.classItemId,
+        actorType: type,
+        cardSelector: CARD_SELECTOR
+    });
+}
+
+async function validateNonPsionicControl(page) {
+    return page.evaluate(async cardSelector => {
+        const actor = await Actor.create({
+            name: 'Playwright F-09 Non-Psionic Control',
+            type: 'character'
+        });
+        const app = actor.sheet;
+        const delay = ms => new Promise(resolve => {
+            setTimeout(resolve, ms);
+        });
+
+        try {
+            app.render({ force: true, mode: app.constructor.MODES.EDIT });
+            await delay(800);
+            return app.element?.querySelectorAll(cardSelector).length ?? 0;
+        } finally {
+            await app.close();
+            await actor.delete();
+        }
+    }, CARD_SELECTOR);
+}
+
+test.describe('Psionicist manifesting card', () => {
+    test.beforeEach(async ({ page }) => {
+        await loginUser(page, 'Gamemaster');
+    });
+
+    test('reconciles one current card on character and NPC sheets', async ({ page }) => {
+        const results = {};
+        for (const type of ['character', 'npc']) {
+            const fixture = await createPsionicActor(page, type);
+            results[type] = await validatePsionicActor(page, fixture, type);
+        }
+
+        for (const result of Object.values(results)) {
+            expect(result.initial).toEqual({
+                directTopSections: 1,
+                obsoleteSelectorMatches: 0,
+                cardCount: 1,
+                ability: '+4',
+                attack: '+6',
+                save: '14',
+                limit: '2',
+                primary: 'false'
+            });
+            expect(result.partial.hookCalls).toBeGreaterThanOrEqual(20);
+            expect(result.partial).toEqual({
+                hookCalls: expect.any(Number),
+                sameTopSection: true,
+                cardReplaced: true,
+                cardCount: 1,
+                ability: '+4',
+                attack: '+6',
+                save: '14',
+                limit: '2',
+                primary: 'false'
+            });
+            expect(result.replacement).toEqual({
+                topSectionReplaced: true,
+                cardCount: 1,
+                ability: '+4',
+                attack: '+6',
+                save: '14',
+                limit: '2',
+                primary: 'false'
+            });
+            expect(result.currentValues).toEqual({
+                cardCount: 1,
+                ability: '+5',
+                attack: '+7',
+                save: '15',
+                limit: '2',
+                primary: 'false'
+            });
+            expect(result.listener).toEqual({
+                updatesAfterNativeClick: 0,
+                updatesAfterModuleClick: 1,
+                actorSpellcasting: 'int',
+                moduleCardCount: 1,
+                primary: 'true'
+            });
+            expect(result.fullRender).toEqual({
+                topSectionReplaced: true,
+                cardCount: 1,
+                ability: '+5',
+                attack: '+7',
+                save: '15',
+                limit: '2',
+                primary: 'true'
+            });
+            expect(result.cardCountAfterEligibilityRemoval).toBe(0);
+        }
+
+        expect(await validateNonPsionicControl(page)).toBe(0);
+    });
+
+    test('allows a Player2 owner to update primary spellcasting once', async ({ page }) => {
+        const fixture = await createPsionicActor(page, 'character', 'Player2');
+        let result;
+
+        try {
+            await page.goto('/join');
+            await loginUser(page, 'Player2');
+            result = await page.evaluate(async ({ actorId, cardSelector }) => {
+                const actor = game.actors.get(actorId);
+                const app = actor.sheet;
+                const delay = ms => new Promise(resolve => {
+                    setTimeout(resolve, ms);
+                });
+                const waitFor = async predicate => {
+                    for (let attempt = 0; attempt < 50; attempt++) {
+                        if (predicate()) {
+                            return;
+                        }
+                        await delay(100);
+                    }
+                    throw new Error('Timed out waiting for Player2 manifesting card state');
+                };
+                let spellcastingUpdates = 0;
+                const updateHookId = Hooks.on('preUpdateActor', (updatedActor, changes) => {
+                    if (updatedActor === actor && foundry.utils.hasProperty(changes, 'system.attributes.spellcasting')) {
+                        spellcastingUpdates++;
+                    }
+                });
+
+                try {
+                    app.render({ force: true, mode: app.constructor.MODES.EDIT });
+                    await waitFor(() => app.element?.querySelectorAll(cardSelector).length === 1);
+                    const card = app.element.querySelector(cardSelector);
+                    card.querySelector('button[data-action="spellcasting"]').click();
+                    await waitFor(() => actor.system.attributes.spellcasting === 'int');
+
+                    return {
+                        actorIsOwner: actor.isOwner,
+                        cardCount: app.element.querySelectorAll(cardSelector).length,
+                        spellcastingUpdates,
+                        actorSpellcasting: actor.system.attributes.spellcasting
+                    };
+                } finally {
+                    Hooks.off('preUpdateActor', updateHookId);
+                    await app.close();
+                }
+            }, { actorId: fixture.actorId, cardSelector: CARD_SELECTOR });
+        } finally {
+            await page.goto('/join');
+            await loginUser(page, 'Gamemaster');
+            await page.evaluate(async actorId => {
+                await game.actors.get(actorId)?.delete();
+            }, fixture.actorId);
+        }
+
+        expect(result).toEqual({
+            actorIsOwner: true,
+            cardCount: 1,
+            spellcastingUpdates: 1,
+            actorSpellcasting: 'int'
+        });
+    });
+});

--- a/src/features/psionics/ui-spellbook-card.js
+++ b/src/features/psionics/ui-spellbook-card.js
@@ -1,6 +1,16 @@
 import { getPowerLimit } from './ui-common';
 import { id as module_id } from '../../../module.json';
 
+const MANIFESTING_CARD_SELECTOR = '[data-sosly-card="psionic-manifesting"]';
+const SPELLBOOK_TOP_SELECTOR = '[data-application-part="spells"] > .top';
+const manifestingRenderTokens = new WeakMap();
+
+function removeManifestingCards(element) {
+    for (const card of element.querySelectorAll(MANIFESTING_CARD_SELECTOR)) {
+        card.remove();
+    }
+}
+
 /**
  * @param {Application} app
  * @param {HTMLElement} element
@@ -8,12 +18,17 @@ import { id as module_id } from '../../../module.json';
  * @param {object} options
  */
 export async function injectPsionicistManifestingCard(app, element, context, options) {
+    const renderToken = Symbol('psionic-manifesting-render');
+    manifestingRenderTokens.set(app, renderToken);
+
     if (!context.actor) {
+        removeManifestingCards(element);
         return;
     }
 
     const psionicistClass = context.actor.classes?.psionicist;
     if (!psionicistClass) {
+        removeManifestingCards(element);
         return;
     }
 
@@ -23,11 +38,7 @@ export async function injectPsionicistManifestingCard(app, element, context, opt
     const powerLimit = getPowerLimit(context.actor);
 
     if (powerLimit === null) {
-        return;
-    }
-
-    const topSection = element.querySelector('.spells .top');
-    if (!topSection) {
+        removeManifestingCards(element);
         return;
     }
 
@@ -49,9 +60,28 @@ export async function injectPsionicistManifestingCard(app, element, context, opt
         templateData
     );
 
-    topSection.insertAdjacentHTML('beforeend', cardHTML);
+    if (manifestingRenderTokens.get(app) !== renderToken) {
+        return;
+    }
 
-    const button = topSection.querySelector(`.spellcasting[data-ability="${abilityId}"] button[data-action="spellcasting"]`);
+    const topSection = element.querySelector(SPELLBOOK_TOP_SELECTOR);
+    if (!topSection) {
+        removeManifestingCards(element);
+        return;
+    }
+
+    const template = document.createElement('template');
+    template.innerHTML = cardHTML.trim();
+    const card = template.content.firstElementChild;
+    if (!card) {
+        removeManifestingCards(element);
+        return;
+    }
+
+    removeManifestingCards(element);
+    topSection.appendChild(card);
+
+    const button = card.querySelector('button[data-action="spellcasting"]');
     if (button) {
         button.addEventListener('click', () => {
             context.actor.update({ 'system.attributes.spellcasting': abilityId });

--- a/templates/features/psionics/manifesting-card.hbs
+++ b/templates/features/psionics/manifesting-card.hbs
@@ -1,4 +1,4 @@
-<div class="spellcasting card" data-ability="{{abilityId}}">
+<div class="spellcasting card" data-ability="{{abilityId}}" data-sosly-card="psionic-manifesting">
     <div class="header">
         <h3>Psionicist Manifesting</h3>
         <button type="button" class="radio-button" data-action="spellcasting" data-tooltip="DND5E.SpellAbilitySet" aria-pressed="{{#if isPrimary}}true{{else}}false{{/if}}" aria-label="Set as Primary Spellcasting Ability"></button>


### PR DESCRIPTION
## Summary

- Target the current dnd5e spellbook DOM and reconcile one module-owned manifesting card.
- Prevent stale asynchronous renders and scope the primary-spellcasting listener to the module card.
- Add character, NPC, repeated-render, stale-removal, and Player2 ownership regression coverage.

## Validation

- JavaScript lint passes with one pre-existing Breather warning.
- The Rollup code build passes.
- Both focused Playwright tests pass against Foundry 13.350 and dnd5e 5.2.5.
- Live GM and Player2 checks show one current card on the preserved character and NPC fixtures.