### PR TITLE
Restore Psionic Disciplines section

### DIFF
--- a/src/features/psionics/playwright.js
+++ b/src/features/psionics/playwright.js
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import { loginUser } from '../../testing/foundry-helpers.js';
 
 const CARD_SELECTOR = '[data-sosly-card="psionic-manifesting"]';
+const DISCIPLINE_SECTION_SELECTOR = '[data-sosly-section="psionic-disciplines"]';
 const CLASS_ID = 'RZUGlaJPnjd23lWC';
 const CLASSES_PACK = 'sosly-5e-house-rules.classes';
 
@@ -356,5 +357,319 @@ test.describe('Psionicist manifesting card', () => {
             spellcastingUpdates: 1,
             actorSpellcasting: 'int'
         });
+    });
+});
+
+async function createDisciplineActor(page, type, ownerName = null) {
+    return page.evaluate(async ({actorType, actorOwnerName}) => {
+        const source = {
+            name: `Playwright F-10 ${actorType}`,
+            type: actorType
+        };
+        if (actorOwnerName) {
+            const owner = game.users.getName(actorOwnerName);
+            source.ownership = {
+                default: CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE,
+                [owner.id]: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER
+            };
+        }
+
+        const actor = await Actor.create(source);
+        const [discipline, unrelated] = await actor.createEmbeddedDocuments('Item', [
+            {
+                name: 'Playwright F-10 Discipline',
+                type: 'feat',
+                system: {type: {value: 'discipline', subtype: 'awa'}}
+            },
+            {
+                name: 'Playwright F-10 Unrelated Feature',
+                type: 'feat',
+                system: {type: {value: 'feat', subtype: ''}}
+            }
+        ]);
+
+        return {
+            actorId: actor.id,
+            disciplineId: discipline.id,
+            unrelatedId: unrelated.id
+        };
+    }, {actorType: type, actorOwnerName: ownerName});
+}
+
+async function validateDisciplineSection(page, fixture) {
+    return page.evaluate(async ({actorId, disciplineId, unrelatedId, sectionSelector}) => {
+        const actor = game.actors.get(actorId);
+        const app = actor.sheet;
+        const renderHook = 'renderCharacterActorSheet';
+        const delay = ms => new Promise(resolve => {
+            setTimeout(resolve, ms);
+        });
+        const waitFor = async predicate => {
+            for (let attempt = 0; attempt < 50; attempt++) {
+                if (predicate()) {
+                    return;
+                }
+                await delay(100);
+            }
+            throw new Error('Timed out waiting for the Psionic Disciplines section');
+        };
+        const getFeaturesPart = () => app.element?.querySelector('[data-application-part="features"]');
+        const getSections = () => Array.from(app.element?.querySelectorAll(sectionSelector) ?? []);
+        const getDisciplineRows = () => Array.from(
+            app.element?.querySelectorAll(`[data-item-id="${disciplineId}"]`) ?? []
+        );
+        const getUnrelatedRows = () => Array.from(
+            app.element?.querySelectorAll(`[data-item-id="${unrelatedId}"]`) ?? []
+        );
+        const summarize = () => {
+            const sections = getSections();
+            const disciplineRows = getDisciplineRows();
+            const unrelatedRows = getUnrelatedRows();
+            return {
+                sectionCount: sections.length,
+                featuresSectionCount: sections.filter(section => section.closest(
+                    '[data-application-part="features"]'
+                )).length,
+                effectsSectionCount: sections.filter(section => section.closest(
+                    '[data-application-part="effects"]'
+                )).length,
+                disciplineRowCount: disciplineRows.length,
+                disciplineRowsInFeatures: disciplineRows.filter(row => row.closest(
+                    '[data-application-part="features"]'
+                )).length,
+                disciplineRowsInEffects: disciplineRows.filter(row => row.closest(
+                    '[data-application-part="effects"]'
+                )).length,
+                unrelatedRowCount: unrelatedRows.length,
+                unrelatedRowsInOther: unrelatedRows.filter(row => row.closest(
+                    '.items-section[data-group-origin="other"]'
+                )).length,
+                subtitle: disciplineRows[0]?.querySelector('.subtitle')?.textContent.trim()
+            };
+        };
+
+        try {
+            app.render({force: true, mode: app.constructor.MODES.EDIT});
+            await waitFor(() => getSections().length === 1);
+            await delay(300);
+
+            const initial = summarize();
+            const initialFeaturesPart = getFeaturesPart();
+            const initialSection = getSections()[0];
+            const initialRow = getDisciplineRows()[0];
+            const initialControl = initialRow.querySelector('[data-action]');
+            const initialOtherSection = getUnrelatedRows()[0].closest('.items-section');
+
+            for (let iteration = 0; iteration < 20; iteration++) {
+                Hooks.callAll(renderHook, app, app.element, {actor}, {});
+            }
+            const repeated = {
+                ...summarize(),
+                sameFeaturesPart: getFeaturesPart() === initialFeaturesPart,
+                sameSection: getSections()[0] === initialSection,
+                sameRow: getDisciplineRows()[0] === initialRow,
+                sameControl: getDisciplineRows()[0].querySelector('[data-action]') === initialControl,
+                sameOtherSection: getUnrelatedRows()[0].closest('.items-section') === initialOtherSection
+            };
+
+            app.render({parts: ['sidebar']});
+            await delay(300);
+            const featuresPartSurvived = getFeaturesPart() === initialFeaturesPart;
+            const partial = {
+                ...summarize(),
+                rowPreservedWhenFeaturesPartSurvived: !featuresPartSurvived
+                    || getDisciplineRows()[0] === initialRow
+            };
+
+            const featuresBeforeReplacement = getFeaturesPart();
+            app.render({parts: ['features']});
+            await waitFor(() => getFeaturesPart() !== featuresBeforeReplacement && getSections().length === 1);
+            const replacement = {
+                ...summarize(),
+                featuresPartReplaced: getFeaturesPart() !== featuresBeforeReplacement
+            };
+
+            const canonicalSection = getSections()[0];
+            const duplicateSection = canonicalSection.cloneNode(true);
+            canonicalSection.parentElement.append(duplicateSection);
+            const duplicateRow = getDisciplineRows()[0].cloneNode(true);
+            getUnrelatedRows()[0].closest('.items-section').querySelector('.item-list').append(duplicateRow);
+            Hooks.callAll(renderHook, app, app.element, {actor}, {});
+            const consolidated = summarize();
+
+            const discipline = actor.items.get(disciplineId);
+            await discipline.update({
+                'system.type.value': 'feat',
+                'system.type.subtype': ''
+            }, {render: false});
+            Hooks.callAll(renderHook, app, app.element, {actor}, {});
+            const removed = summarize();
+
+            await discipline.update({
+                'system.type.value': 'discipline',
+                'system.type.subtype': 'awa'
+            }, {render: false});
+            Hooks.callAll(renderHook, app, app.element, {actor}, {});
+            const restored = summarize();
+
+            return {initial, repeated, partial, replacement, consolidated, removed, restored};
+        } finally {
+            await app.close();
+            await actor.delete();
+        }
+    }, {...fixture, sectionSelector: DISCIPLINE_SECTION_SELECTOR});
+}
+
+async function validateDisciplineNpcControl(page, fixture) {
+    return page.evaluate(async ({actorId, disciplineId, sectionSelector}) => {
+        const actor = game.actors.get(actorId);
+        const app = actor.sheet;
+
+        try {
+            app.render({force: true, mode: app.constructor.MODES.EDIT});
+            await new Promise(resolve => {
+                setTimeout(resolve, 500);
+            });
+            return {
+                sectionCount: app.element?.querySelectorAll(sectionSelector).length ?? 0,
+                disciplineRowCount: app.element?.querySelectorAll(
+                    `[data-item-id="${disciplineId}"]`
+                ).length ?? 0
+            };
+        } finally {
+            await app.close();
+            await actor.delete();
+        }
+    }, {...fixture, sectionSelector: DISCIPLINE_SECTION_SELECTOR});
+}
+
+test.describe('Psionic discipline section', () => {
+    test.beforeEach(async ({page}) => {
+        await loginUser(page, 'Gamemaster');
+    });
+
+    test.afterEach(async ({page}) => {
+        const isGamemaster = await page.evaluate(() => game?.user?.isGM ?? false);
+        if (!isGamemaster) {
+            await page.goto('/join');
+            await loginUser(page, 'Gamemaster');
+        }
+        await page.evaluate(async () => {
+            const actors = game.actors.filter(actor => actor.name.startsWith('Playwright F-10 '));
+            for (const actor of actors) {
+                await actor.delete();
+            }
+        });
+    });
+
+    test('reconciles one Features section while leaving NPC sheets unchanged', async ({page}) => {
+        const character = await validateDisciplineSection(page, await createDisciplineActor(page, 'character'));
+        const stable = {
+            sectionCount: 1,
+            featuresSectionCount: 1,
+            effectsSectionCount: 0,
+            disciplineRowCount: 1,
+            disciplineRowsInFeatures: 1,
+            disciplineRowsInEffects: 0,
+            unrelatedRowCount: 1,
+            unrelatedRowsInOther: 1,
+            subtitle: 'Awakened'
+        };
+
+        expect(character.initial).toEqual(stable);
+        expect(character.repeated).toEqual({
+            ...stable,
+            sameFeaturesPart: true,
+            sameSection: true,
+            sameRow: true,
+            sameControl: true,
+            sameOtherSection: true
+        });
+        expect(character.partial).toEqual({...stable, rowPreservedWhenFeaturesPartSurvived: true});
+        expect(character.replacement).toEqual({...stable, featuresPartReplaced: true});
+        expect(character.consolidated).toEqual(stable);
+        expect(character.removed).toEqual({
+            ...stable,
+            sectionCount: 0,
+            featuresSectionCount: 0,
+            disciplineRowCount: 1,
+            subtitle: 'Awakened'
+        });
+        expect(character.restored).toEqual(stable);
+
+        const npcFixture = await createDisciplineActor(page, 'npc');
+        expect(await validateDisciplineNpcControl(page, npcFixture)).toEqual({
+            sectionCount: 0,
+            disciplineRowCount: 1
+        });
+    });
+
+    test('shows the section and owner controls to Player2', async ({page}) => {
+        const fixture = await createDisciplineActor(page, 'character', 'Player2');
+        let result;
+
+        try {
+            await page.goto('/join');
+            await loginUser(page, 'Player2');
+            result = await page.evaluate(async ({actorId, disciplineId, sectionSelector}) => {
+                const actor = game.actors.get(actorId);
+                const app = actor.sheet;
+                const delay = ms => new Promise(resolve => {
+                    setTimeout(resolve, ms);
+                });
+                const waitFor = async predicate => {
+                    for (let attempt = 0; attempt < 50; attempt++) {
+                        if (predicate()) {
+                            return;
+                        }
+                        await delay(100);
+                    }
+                    throw new Error('Timed out waiting for Player2 discipline section state');
+                };
+
+                try {
+                    app.render({force: true, mode: app.constructor.MODES.EDIT});
+                    await waitFor(() => app.element?.querySelectorAll(sectionSelector).length === 1);
+                    for (let iteration = 0; iteration < 20; iteration++) {
+                        Hooks.callAll('renderCharacterActorSheet', app, app.element, {actor}, {});
+                    }
+                    const row = app.element.querySelector(`[data-item-id="${disciplineId}"]`);
+                    return {
+                        actorIsOwner: actor.isOwner,
+                        sectionCount: app.element.querySelectorAll(sectionSelector).length,
+                        disciplineRowCount: app.element.querySelectorAll(
+                            `[data-item-id="${disciplineId}"]`
+                        ).length,
+                        sectionInFeatures: Boolean(app.element.querySelector(
+                            `[data-application-part="features"] ${sectionSelector}`
+                        )),
+                        sectionInEffects: Boolean(app.element.querySelector(
+                            `[data-application-part="effects"] ${sectionSelector}`
+                        )),
+                        enabledControls: Array.from(row.querySelectorAll('[data-action]')).filter(
+                            control => !control.disabled
+                        ).length
+                    };
+                } finally {
+                    await app.close();
+                }
+            }, {...fixture, sectionSelector: DISCIPLINE_SECTION_SELECTOR});
+        } finally {
+            await page.goto('/join');
+            await loginUser(page, 'Gamemaster');
+            await page.evaluate(async actorId => {
+                await game.actors.get(actorId)?.delete();
+            }, fixture.actorId);
+        }
+
+        expect(result).toEqual({
+            actorIsOwner: true,
+            sectionCount: 1,
+            disciplineRowCount: 1,
+            sectionInFeatures: true,
+            sectionInEffects: false,
+            enabledControls: expect.any(Number)
+        });
+        expect(result.enabledControls).toBeGreaterThan(0);
     });
 });

--- a/src/features/psionics/psionics.js
+++ b/src/features/psionics/psionics.js
@@ -1,4 +1,5 @@
 import { addPsionicSubtitles } from './ui-spellbook';
+import { reorganizePsionicDisciplines } from './ui-features';
 
 import { registerPsychicFocusManagement } from './psychic-focus';
 import { registerArgonIntegration } from './ui-argon';
@@ -57,6 +58,7 @@ export function registerPsionics() {
     setupPsionicOptions();
     Hooks.on('renderCharacterActorSheet', addPsionicSubtitles);
     Hooks.on('renderNPCActorSheet', addPsionicSubtitles);
+    Hooks.on('renderCharacterActorSheet', reorganizePsionicDisciplines);
     Hooks.on('renderCharacterActorSheet', injectPsionicistManifestingCard);
     Hooks.on('renderNPCActorSheet', injectPsionicistManifestingCard);
     registerPsychicFocusManagement();

--- a/src/features/psionics/ui-features.js
+++ b/src/features/psionics/ui-features.js
@@ -1,108 +1,168 @@
-import {id as module_id} from '../../../module.json';
-import {logger} from '../../utils/logger';
+const DISCIPLINE_GROUP = 'discipline';
+const DISCIPLINE_SECTION_SELECTOR = '[data-sosly-section="psionic-disciplines"]';
+const FEATURES_PART_SELECTOR = '[data-application-part="features"]';
+const GROUP_KEYS = ['origin', 'activation'];
 
 function isPsionicDiscipline(item) {
     return item.type === 'feat' && item.system.type?.value === 'discipline';
 }
 
-async function createPsionicDisciplinesSection(element) {
-    const featuresSection = element.querySelector('.features-list');
-    if (!featuresSection) {
-        return null;
-    }
+function getFeatureRows(featuresPart) {
+    return Array.from(featuresPart.querySelectorAll('.item-list > [data-item-id]'));
+}
 
-    const sectionData = {
-        label: 'Psionic Disciplines',
-        categories: [
-            {classes: 'item-uses', label: 'DND5E.Uses'},
-            {classes: 'item-recovery', label: 'DND5E.Recovery'},
-            {classes: 'item-controls'}
-        ]
-    };
+function getNativeSection(featuresPart, groupOrigin) {
+    const sections = Array.from(featuresPart.querySelectorAll('.items-section[data-group-origin]'));
+    return sections.find(section => {
+        return !section.matches(DISCIPLINE_SECTION_SELECTOR)
+            && section.dataset.groupOrigin === groupOrigin;
+    });
+}
 
-    try {
-        const sectionHtml = await renderTemplate(
-            `modules/${module_id}/templates/features/psionics/disciplines-section.hbs`,
-            sectionData
-        );
-
-        const tempDiv = document.createElement('div');
-        tempDiv.innerHTML = sectionHtml;
-        const section = tempDiv.firstElementChild;
-
-        const otherSection = element.querySelector('[data-type="other"]');
-        if (otherSection) {
-            otherSection.parentNode.insertBefore(section, otherSection);
-        } else {
-            const sections = element.querySelectorAll('.items-section');
-            const lastSection = sections[sections.length - 1];
-            if (lastSection) {
-                lastSection.parentNode.insertBefore(section, lastSection.nextSibling);
-            } else {
-                featuresSection.appendChild(section);
-            }
+function preserveNativeGrouping(row) {
+    for (const groupKey of GROUP_KEYS) {
+        const groupAttribute = `data-group-${groupKey}`;
+        const originalAttribute = `data-sosly-original-group-${groupKey}`;
+        if (!row.hasAttribute(originalAttribute)) {
+            row.setAttribute(originalAttribute, row.getAttribute(groupAttribute) ?? '');
         }
-
-        return section;
-    } catch (error) {
-        logger.warn(`Failed to create Psionic Disciplines section: ${error}`);
-        return null;
+        row.setAttribute(groupAttribute, DISCIPLINE_GROUP);
     }
 }
 
-export async function reorganizePsionicDisciplines(app, element, context, options) {
-    if (!context.actor) {
+function restoreNativeGrouping(row, featuresPart) {
+    for (const groupKey of GROUP_KEYS) {
+        const groupAttribute = `data-group-${groupKey}`;
+        const originalAttribute = `data-sosly-original-group-${groupKey}`;
+        if (!row.hasAttribute(originalAttribute)) {
+            continue;
+        }
+
+        const originalGroup = row.getAttribute(originalAttribute);
+        if (originalGroup) {
+            row.setAttribute(groupAttribute, originalGroup);
+        } else {
+            row.removeAttribute(groupAttribute);
+        }
+        row.removeAttribute(originalAttribute);
+    }
+
+    const targetSection = getNativeSection(featuresPart, row.dataset.groupOrigin ?? 'other')
+        ?? getNativeSection(featuresPart, 'other');
+    targetSection?.querySelector('.item-list')?.append(row);
+}
+
+function createDisciplineSection(featuresPart) {
+    const featuresList = featuresPart.querySelector('[data-item-list="features"]');
+    const referenceSection = getNativeSection(featuresPart, 'other')
+        ?? featuresPart.querySelector('.items-section');
+    const referenceHeader = referenceSection?.querySelector('.items-header');
+    const referenceItemList = referenceSection?.querySelector('.item-list');
+    if (!featuresList || !referenceSection || !referenceHeader || !referenceItemList) {
+        return null;
+    }
+
+    const section = referenceSection.cloneNode(false);
+    section.hidden = false;
+    section.dataset.soslySection = 'psionic-disciplines';
+    section.dataset.groupOrigin = DISCIPLINE_GROUP;
+    section.dataset.groupActivation = DISCIPLINE_GROUP;
+
+    const header = referenceHeader.cloneNode(true);
+    const label = header.querySelector('.item-name');
+    if (label) {
+        label.textContent = 'Psionic Disciplines';
+    }
+
+    const itemList = referenceItemList.cloneNode(false);
+    itemList.replaceChildren();
+    section.append(header, itemList);
+    referenceSection.before(section);
+    return section;
+}
+
+function setDisciplineSubtitle(row, discipline) {
+    const subtitle = row.querySelector('.item-row > .item-name .subtitle');
+    const subtype = discipline.system.type?.subtype;
+    if (!subtitle || !subtype) {
         return;
     }
 
-    if (context.actor.type !== 'character') {
+    const label = CONFIG.DND5E.featureTypes?.discipline?.subtypes?.[subtype];
+    if (label) {
+        subtitle.textContent = label;
+    }
+}
+
+function refreshInventorySections(featuresPart) {
+    featuresPart.querySelector('.inventory-element')?._cacheSections?.();
+}
+
+export function reorganizePsionicDisciplines(app, element, context) {
+    const actor = context.actor;
+    if (!actor || actor.type !== 'character') {
         return;
     }
 
-    if (!element.querySelector('.features-list')) {
+    const featuresPart = element.querySelector(FEATURES_PART_SELECTOR);
+    if (!featuresPart) {
         return;
     }
 
-    const psionicDisciplines = context.actor.items.filter(isPsionicDiscipline);
-    if (!psionicDisciplines.length) {
-        return;
-    }
+    const disciplines = actor.items.filter(isPsionicDiscipline)
+        .sort((left, right) => left.name.localeCompare(right.name));
+    const disciplineIds = new Set(disciplines.map(discipline => discipline.id));
+    const existingSections = Array.from(featuresPart.querySelectorAll(DISCIPLINE_SECTION_SELECTOR));
 
-    const otherFeaturesSection = element.querySelector('[data-type="other"]');
-    const disciplinesSection = await createPsionicDisciplinesSection(element);
-    if (!disciplinesSection) {
-        return;
-    }
-
-    const itemList = disciplinesSection.querySelector('.item-list');
-
-    psionicDisciplines
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .forEach(discipline => {
-            const itemElement = element.querySelector(`[data-item-id="${discipline.id}"]`);
-            if (!itemElement) {
-                return;
+    for (const section of existingSections) {
+        const rows = Array.from(section.querySelectorAll('.item-list > [data-item-id]'));
+        for (const row of rows) {
+            if (!disciplineIds.has(row.dataset.itemId)) {
+                restoreNativeGrouping(row, featuresPart);
             }
+        }
+    }
 
-            itemElement.setAttribute('data-grouped', 'discipline');
+    const matchingRows = getFeatureRows(featuresPart).filter(row => disciplineIds.has(row.dataset.itemId));
+    if (!matchingRows.length) {
+        for (const section of existingSections) {
+            section.remove();
+        }
+        refreshInventorySections(featuresPart);
+        return;
+    }
 
-            const subtitleElement = itemElement.querySelector('.item-row > .item-name .subtitle');
-            if (subtitleElement && discipline.system.type?.subtype) {
-                const disciplineSubtype = CONFIG.DND5E
-                    .featureTypes?.discipline?.subtypes?.[discipline.system.type.subtype];
-                if (disciplineSubtype) {
-                    subtitleElement.textContent = disciplineSubtype;
-                }
+    const disciplineSection = existingSections[0] ?? createDisciplineSection(featuresPart);
+    if (!disciplineSection) {
+        return;
+    }
+
+    const disciplineList = disciplineSection.querySelector('.item-list');
+    for (const discipline of disciplines) {
+        const rows = getFeatureRows(featuresPart).filter(row => row.dataset.itemId === discipline.id);
+        const row = rows.find(candidate => candidate.closest(DISCIPLINE_SECTION_SELECTOR) === disciplineSection)
+            ?? rows[0];
+        if (!row) {
+            continue;
+        }
+
+        for (const duplicate of rows) {
+            if (duplicate !== row) {
+                duplicate.remove();
             }
+        }
 
-            itemList.appendChild(itemElement);
-        });
-
-    if (!disciplinesSection.querySelector('.item-list li')) {
-        disciplinesSection.remove();
+        preserveNativeGrouping(row);
+        setDisciplineSubtitle(row, discipline);
+        disciplineList.append(row);
     }
 
-    if (otherFeaturesSection && !otherFeaturesSection.querySelector('.item-list li')) {
-        otherFeaturesSection.remove();
+    for (const duplicateSection of existingSections.slice(1)) {
+        duplicateSection.remove();
     }
+
+    if (!disciplineList.querySelector('[data-item-id]')) {
+        disciplineSection.remove();
+    }
+    refreshInventorySections(featuresPart);
 }


### PR DESCRIPTION
## Summary

- restore the dedicated Psionic Disciplines section on character Features tabs
- preserve existing item rows, controls, native grouping, and responsive section metadata
- reconcile repeated and partial sheet renders without duplicates or Effects-tab leakage
- leave NPC sheets unchanged

## Validation

- reproduced F-10 with the focused regression tests before the production change
- `npm run test:unit` (8 passed)
- full psionics Playwright file (4 passed)
- focused F-10 Playwright tests (2 passed)
- `npm run lint:code` (0 errors; one pre-existing warning in breather.js)
- `npm run build:code`
- live Foundry 13.350 and dnd5e 5.2.5 validation as Gamemaster and Player2 on port 30000

F-10 remains pending manual reviewer confirmation before it is marked repaired.