### PR TITLE
Fix Argon wrapper registration idempotency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "test:integration": "playwright test",
         "test:integration:headed": "playwright test --headed",
         "test:integration:ui": "playwright test --ui",
-        "test:unit": "node --test src/features/low-light-vision/light-union-cache.test.js src/features/low-light-vision/vision-source-polygons.test.js",
+        "test:unit": "node --test src/features/low-light-vision/light-union-cache.test.js src/features/low-light-vision/vision-source-polygons.test.js src/features/psionics/ui-argon.test.js",
         "watch": "npm-run-all --parallel watch:*",
         "watch:code": "npm-watch build:code",
         "watch:lint": "npm-watch lint:code",

--- a/src/features/psionics/ui-argon.js
+++ b/src/features/psionics/ui-argon.js
@@ -311,6 +311,8 @@ export function registerArgonIntegration() {
     let DND5eButtonPanelButtonClass = null;
     let buttonClassPatched = false;
     let needsFirstRerender = false;
+    const patchedCoreHUDClasses = new WeakSet();
+    const patchedPanelClasses = new WeakSet();
 
     function patchButtonClass(buttonClass) {
         if (buttonClassPatched || !buttonClass) {
@@ -366,13 +368,17 @@ export function registerArgonIntegration() {
     }
 
     Hooks.on('argonInit', CoreHUD => {
+        if (patchedCoreHUDClasses.has(CoreHUD)) {
+            return;
+        }
+
         const originalDefineMainPanels = CoreHUD.defineMainPanels;
 
         CoreHUD.defineMainPanels = function(panels) {
             originalDefineMainPanels.call(this, panels);
 
             for (const PanelClass of panels) {
-                if (!PanelClass.prototype._getButtons) {
+                if (!PanelClass.prototype._getButtons || patchedPanelClasses.has(PanelClass)) {
                     continue;
                 }
 
@@ -393,8 +399,10 @@ export function registerArgonIntegration() {
                     }
                     return processPanelButtons(buttons, this.actor, DND5eButtonPanelButtonClass);
                 };
+                patchedPanelClasses.add(PanelClass);
             }
         };
+        patchedCoreHUDClasses.add(CoreHUD);
 
         Hooks.once('renderCoreHUD', (app, html, data) => {
             if (needsFirstRerender) {

--- a/src/features/psionics/ui-argon.test.js
+++ b/src/features/psionics/ui-argon.test.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {fileURLToPath} from 'node:url';
+
+import {rollup} from 'rollup';
+
+test('does not stack Argon wrappers under repeated initialization and panel registration', async () => {
+    const listeners = new Map();
+    const onceListeners = new Map();
+    const registeredPanels = [];
+
+    globalThis.game = {
+        modules: new Map([
+            ['enhancedcombathud', {active: true}]
+        ])
+    };
+    globalThis.Hooks = {
+        on(event, callback) {
+            const callbacks = listeners.get(event) ?? [];
+            callbacks.push(callback);
+            listeners.set(event, callbacks);
+        },
+        once(event, callback) {
+            const callbacks = onceListeners.get(event) ?? [];
+            callbacks.push(callback);
+            onceListeners.set(event, callbacks);
+        }
+    };
+
+    const {registerArgonIntegration} = await loadArgonIntegration();
+    registerArgonIntegration();
+
+    class CoreHUD {}
+    CoreHUD.defineMainPanels = panels => registeredPanels.push(...panels);
+
+    const [initializeArgon] = listeners.get('argonInit');
+    initializeArgon(CoreHUD);
+    const defineMainPanels = CoreHUD.defineMainPanels;
+
+    initializeArgon(CoreHUD);
+    assert.equal(CoreHUD.defineMainPanels, defineMainPanels);
+    assert.equal(onceListeners.get('renderCoreHUD').length, 1);
+
+    class Panel {
+        async _getButtons() {
+            return [];
+        }
+    }
+
+    CoreHUD.defineMainPanels([Panel]);
+    const getButtons = Panel.prototype._getButtons;
+
+    CoreHUD.defineMainPanels([Panel]);
+    assert.equal(Panel.prototype._getButtons, getButtons);
+    assert.deepEqual(registeredPanels, [Panel, Panel]);
+});
+
+async function loadArgonIntegration() {
+    const bundle = await rollup({
+        input: fileURLToPath(new URL('./ui-argon.js', import.meta.url))
+    });
+    const {output} = await bundle.generate({format: 'es'});
+    await bundle.close();
+
+    const encodedModule = Buffer.from(output[0].code).toString('base64');
+    return import(`data:text/javascript;base64,${encodedModule}`);
+}


### PR DESCRIPTION
## Summary
- make SoSly's Argon CoreHUD wrapper idempotent per CoreHUD class
- wrap each Argon panel class at most once while preserving first-time registration
- add a focused regression for repeated `argonInit` and panel registration

## Validation
- `npm run test:unit` (9 passed)
- `npm run lint:code` (0 errors; 1 pre-existing warning in `breather.js`)
- `npm run build:code`
- live Foundry 13.350 / dnd5e 5.2.5 validation with Argon Core 3.1.2 and Argon DND5E 4.3.4: repeated initialization preserved `defineMainPanels` identity, first panel registration wrapped once, and repeated registration preserved `_getButtons` identity

The full build reached pack compilation after the code build and pack migration audit passed, but Foundry held the LevelDB pack database open. No pack data is changed by this repair.